### PR TITLE
 feat: add events support, live streaming examples, and README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,290 @@
-#  Pandlas
+# Pandlas
 
-A Pandas extension for ATLAS, intended to demonstrate how to use the SQLRace API. 
-**This package is not maintained nor officially supported.**
+A Pandas extension for [ATLAS 10](https://www.motionapplied.com/), bridging Python
+DataFrames and the SQLRace API through
+[pythonnet](https://github.com/pythonnet/pythonnet).
+
+> **Note — this package is not maintained nor officially supported by Motion Applied.**
 
 [![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 
+---
 
-This package utilises API from ATLAS and as such requires a valid ATLAS licence with the SQLRace option included.
+## Features
 
-## Installtion
-```
+| Category | Capability |
+|----------|-----------|
+| **Data writing** | Write Pandas DataFrames to ATLAS sessions (SQLite, SSN2, SQL Server) |
+| **Multi-rate** | Mix parameters at different sample rates (1 kHz, 100 Hz, 10 Hz, 1 Hz, …) in the same session |
+| **Synchro data** | Write engine-synchronous (variable-rate) channels with automatic packet management |
+| **Text channels** | Write enumerated/string parameters via TextConversion lookup tables |
+| **Live sessions** | Stream data into live sessions visible in ATLAS via the Server Listener / Recorder |
+| **Parameter metadata** | Custom units, descriptions, display format, display limits, and warning limits per parameter |
+| **Parameter grouping** | Auto-create parameter groups from column naming (e.g. `"Chassis/DamperFL"`) |
+| **Session details** | Set session-level metadata: Driver, Circuit, Vehicle, Event, etc. |
+| **Laps & markers** | Add, update laps, point markers, and range markers (individual or batch) |
+| **Events** | Write discrete events with priority levels and status labels from DataFrames |
+| **Data reading** | Read parameter samples back from historic sessions |
+| **Automation** | Helpers for the ATLAS Automation API (open ATLAS, load sessions) |
+
+## Requirements
+
+- **ATLAS 10** installed with a valid licence (SQLRace option enabled)
+- **Python 3.9 – 3.11**
+
+## Installation
+
+```bash
 pip install "git+https://github.com/owentmfoo/pandlas.git"
 ```
 
-## Package dependencies
-- Pandas
-- pythonnet
-- tqdm
+## Quick Start
 
-# Limitations
-- Only take a dataframe of float or can be converted to float
-- Units are not set for the parameters
-- Must have a DateTime index
+### Write a session
 
+```python
+import pandas as pd
+import numpy as np
+from pandlas import SQLiteConnection
 
-Further possibilities with SQLRace API but not implemented in this Python package
-- Text Channels
-- Units for each parameter
-- Set custom limits and warnings in ATLAS
-- Grouping parameters
+start = pd.Timestamp("now")
+df = pd.DataFrame(
+    {"speed": np.sin(np.linspace(0, 10 * np.pi, 1000))},
+    index=pd.date_range(start, periods=1000, freq="s"),
+)
+
+with SQLiteConnection(r"C:\data\demo.ssndb", "DemoSession", mode="w") as session:
+    df.atlas.to_atlas_session(session)
+```
+
+### Parameter metadata
+
+All metadata is set via dictionaries keyed by `"{column}:{ApplicationGroupName}"`:
+
+```python
+df.atlas.ApplicationGroupName = "MyApp"
+df.atlas.ParameterGroupIdentifier = "Chassis"
+
+df.atlas.units            = {"speed:MyApp": "m/s"}
+df.atlas.descriptions     = {"speed:MyApp": "Vehicle speed"}
+df.atlas.display_format   = {"speed:MyApp": "%6.1f"}
+df.atlas.display_limits   = {"speed:MyApp": (0.0, 400.0)}
+df.atlas.warning_limits   = {"speed:MyApp": (0.0, 370.0)}
+```
+
+### Multi-rate parameters
+
+Write DataFrames at different frequencies into the same session — each gets its
+own channel and sample interval:
+
+```python
+with SQLiteConnection(db_path, "MultiRate", mode="w") as session:
+    # 100 Hz suspension data
+    df_fast = pd.DataFrame(
+        {"damper_fl": data_100hz},
+        index=pd.date_range(start, periods=len(data_100hz), freq="10ms"),
+    )
+    df_fast.atlas.to_atlas_session(session)
+
+    # 1 Hz strategy data
+    df_slow = pd.DataFrame(
+        {"fuel_remaining": data_1hz},
+        index=pd.date_range(start, periods=len(data_1hz), freq="s"),
+    )
+    df_slow.atlas.to_atlas_session(session)
+```
+
+### Laps and markers
+
+```python
+from pandlas import add_lap, add_point_marker, add_range_marker
+
+add_lap(session, start + pd.Timedelta(60, "s"), lap_name="Lap 2")
+add_point_marker(session, start + pd.Timedelta(30, "s"), "Pit Entry")
+add_range_marker(session, start + pd.Timedelta(10, "s"),
+                 start + pd.Timedelta(20, "s"), "Safety Car")
+```
+
+### Synchro (variable-rate) data
+
+Engine-synchronous channels where the sample rate varies with RPM:
+
+```python
+from pandlas import add_synchro_data
+import numpy as np
+
+# samples: float64 array, timestamps_ns: int64 array (nanosecond offsets)
+samples = np.random.randn(50_000)
+timestamps_ns = np.cumsum(np.full(50_000, 80_000, dtype=np.int64))  # ~12.5 kHz
+
+add_synchro_data(
+    session,
+    parameter_name="CylPressure",
+    app_group="EngineSync",
+    samples=samples,
+    timestamps=timestamps_ns,
+    unit="bar",
+    description="Cylinder pressure (crank-synchronous)",
+)
+```
+
+The module handles byte packing, GCD-based delta scaling, automatic packet
+splitting (≤ 65 535 samples per packet), config creation, and sequence-number
+management. See `example/synchro_benchmark.py` for a full benchmark.
+
+### Session details
+
+Set session-level metadata visible in ATLAS session properties:
+
+```python
+from pandlas import set_session_details
+
+set_session_details(session, {
+    "Driver": "Lando Norris",
+    "Circuit": "Silverstone",
+    "Vehicle": "MCL60",
+    "Event": "British GP 2026",
+})
+```
+
+### Events
+
+Write discrete events from a DataFrame — each row becomes an ATLAS event with
+associated numeric values:
+
+```python
+import pandas as pd
+from pandlas import add_events
+
+# Each row = one event; every numeric column is an event value
+events = pd.DataFrame({
+    "timestamp": pd.date_range("2026-04-01 14:00", periods=5, freq="30s"),
+    "Status":         ["LK-001", "LK-002", "LK-003", "LK-004", "LK-005"],
+    "BrakePressure": [32.1, 28.5, 35.0, 30.2, 29.8],
+    "WheelSlip":     [0.12, 0.08, 0.15, 0.10, 0.09],
+})
+
+add_events(
+    session, events,
+    status_column="Status",          # shown in ATLAS Status column
+    description="Brake Lockup",
+    priority="high",                 # "low", "medium", or "high"
+    application_group="BrakeApp",
+)
+```
+
+Events support multiple groups in the same session — just call `add_events()`
+once per event type (e.g. lockups, flags, pit stops).
+
+### Parameter grouping
+
+Use a separator in column names to auto-create parameter groups:
+
+```python
+df = pd.DataFrame({
+    "Chassis/DamperFL": damper_fl_data,
+    "Chassis/DamperFR": damper_fr_data,
+    "Engine/RPM":       rpm_data,
+    "Engine/OilTemp":   oil_data,
+}, index=timestamps)
+
+df.atlas.ApplicationGroupName = "CarData"
+df.atlas.parameter_group_separator = "/"
+df.atlas.to_atlas_session(session)
+# Creates groups "Chassis" and "Engine" automatically
+```
+
+### Text channels
+
+Write enumerated parameters that display as string labels in ATLAS:
+
+```python
+from pandlas import add_text_channel
+
+gears = ["N", "1", "2", "3", "4", "5", "6", "7", "8"]
+gear_values = [gears[i % len(gears)] for i in range(len(timestamps))]
+
+add_text_channel(
+    session,
+    parameter_name="Gear",
+    values=gear_values,
+    timestamps=timestamps,
+    application_group="DriverInputs",
+)
+```
+
+### Live session
+
+```python
+from pandlas import SQLiteConnection
+
+with SQLiteConnection(db_path, "LiveDemo", mode="w", recorder=True) as session:
+    # The session is now visible in ATLAS as a live session.
+    # Write data in a loop and it updates in real time.
+    ...
+```
+
+### Read data back
+
+```python
+from pandlas import SQLiteConnection, get_samples
+
+with SQLiteConnection(db_path, session_key="<key>", mode="r") as session:
+    samples, timestamps = get_samples(session, "speed:MyApp")
+```
+
+## Session Backends
+
+| Backend | Class | Use case |
+|---------|-------|----------|
+| SQLite / SSN2 | `SQLiteConnection`, `Ssn2Session` | Local / file-based sessions |
+| SQL Server | `SQLRaceDBConnection` | Shared database sessions |
+
+## Performance
+
+Data serialisation uses vectorised NumPy operations for both sample bytes and
+timestamp arrays, avoiding Python-level loops on the hot path. Typical
+throughput when writing to SQL Server:
+
+| Data type | Metric | Value |
+|-----------|--------|-------|
+| **Row data** | Config creation (first batch) | ~2–3 s |
+| **Row data** | Streaming write rate | ~40 000–50 000 samples/s |
+| **Synchro** | Write rate (variable-interval) | ~50 000–200 000 samples/s |
+
+Run `example/multirate_session.py` to benchmark your setup. The script writes
+multi-rate row data and synchro signals, then reads back and validates metadata
+and data integrity. For large-scale synchro benchmarks, use
+`example/synchro_benchmark.py`.
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `pandas` | DataFrame core |
+| `numpy` | Vectorised data serialisation |
+| `pythonnet` | .NET CLR interop |
+| `tqdm` | Progress bars |
+| `requests` | HTTP client (live examples only) |
+
+## Known Limitations
+
+- The DataFrame index must be a `DatetimeIndex`
+- Events and text channels require timestamps within the session time range
+
+## Examples
+
+See the [`example/`](example/) directory:
+
+| Script | Description |
+|--------|-------------|
+| `complete_showcase.py` | **All 7 features** in one session — the best starting point |
+| `create_session.py` | Historic session with multiple rates, metadata, laps, and markers |
+| `event_logging.py` | Discrete events (lockups, flags, pit stops) from DataFrames |
+| `live_crypto.py` | 📈 Live Binance ticker — 20 crypto assets streaming at 100 Hz with spike alerts |
+| `live_sessions.py` | Live streaming to SQLite and SQL Server |
+| `live_weather.py` | ☁️ Live Silverstone weather from Open-Meteo with gust/rain events |
+| `multirate_session.py` | Multi-rate performance benchmark with full validation (includes synchro signals) |
+| `session_features.py` | Session details, parameter grouping, and text channels |
+| `synchro_benchmark.py` | Synchro data benchmark — RPM-driven variable-rate channels at 100 K / 1 M / 10 M scale |
+| `where_the_iss_at.py` | Live session fed from the ISS position API |

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,8 +19,8 @@ os.environ['PYTHONNET_CORECLR_RUNTIME_CONFIG'] = r'C:\Program Files\McLaren Appl
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Pandlas'
-copyright = '2024, Owen Foo'
-author = 'Owen Foo'
+copyright = '2026, Owen Foo'
+author = 'Owen Foo; Carles Abella'
 from importlib.metadata import version as package_version
 release = package_version("pandlas")
 

--- a/example/complete_showcase.py
+++ b/example/complete_showcase.py
@@ -1,0 +1,472 @@
+"""Pandlas Complete Showcase
+===========================
+
+A single session demonstrating every Pandlas feature:
+
+  1. Multi-rate row data        — 3 frequency bands with sub-grouped params
+  2. Session details            — Driver, Circuit, Event metadata
+  3. Parameter grouping         — hierarchical auto-grouping via separator
+  4. Laps                       — 10 named laps, one renamed via update_lap
+  5. Point & range markers      — pit events, DRS zones, safety car, sectors
+  6. Synchro (variable-rate)    — engine-synchronous channel
+  7. Text channels              — enumerated string parameters
+  8. Events                     — low / medium / high severity events
+
+Usage:
+    python complete_showcase.py
+"""
+
+import time
+import logging
+import numpy as np
+import pandas as pd
+
+from pandlas import (
+    SQLiteConnection,
+    SQLRaceDBConnection,
+    add_lap,
+    update_lap,
+    add_point_marker,
+    add_range_marker,
+    add_markers_batch,
+    set_session_details,
+    add_synchro_data,
+    add_text_channel,
+    add_events,
+)
+from pandlas.utils import timestamp2long
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Configuration
+# ═══════════════════════════════════════════════════════════════════════
+BACKEND = "sqlserver"
+
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\Showcase.ssndb"
+
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+SESSION_DURATION_S = 120  # 2 minutes — enough for 10 laps
+ORIGIN_T0 = pd.Timestamp.now()
+
+SESSION_DETAILS = {
+    "Driver": "Lando Norris",
+    "Team": "McLaren Racing",
+    "Circuit": "Silverstone",
+    "Vehicle": "MCL60",
+    "Event": "British GP 2026",
+    "Session": "FP1",
+    "Configuration": "High Downforce",
+    "Comment": "Pandlas complete showcase — all features",
+}
+
+# Lap timing: 10 laps of ~12 s each
+LAP_TIMES_S = [0, 12, 23, 34, 45, 56, 67, 78, 89, 100, 111]
+LAP_NAMES = [
+    "Out Lap", "Lap 1", "Lap 2", "Lap 3", "Lap 4",
+    "Lap 5", "Lap 6", "Lap 7", "Lap 8", "Lap 9",
+]
+
+
+def open_connection(mode, identifier="", key=None):
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, session_key=key, mode=mode,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, session_key=key, mode=mode,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Data generators
+# ═══════════════════════════════════════════════════════════════════════
+
+def generate_high_freq_data(origin, duration_s):
+    """100 Hz — fast-changing chassis signals under Chassis/ group."""
+    rng = np.random.default_rng(10)
+    n = duration_s * 100
+    times = pd.date_range(origin, periods=n, freq="10ms")
+    t = np.linspace(0, duration_s, n)
+    return pd.DataFrame({
+        "Chassis/DamperFL":    rng.normal(25, 3, n).astype(np.float32),
+        "Chassis/DamperFR":    rng.normal(25, 3, n).astype(np.float32),
+        "Chassis/DamperRL":    rng.normal(22, 2.5, n).astype(np.float32),
+        "Chassis/DamperRR":    rng.normal(22, 2.5, n).astype(np.float32),
+        "Chassis/RideHeightF": (30 + 5 * np.sin(2 * np.pi * t / 6)
+                                + rng.normal(0, 0.5, n)).astype(np.float32),
+        "Chassis/RideHeightR": (35 + 4 * np.sin(2 * np.pi * t / 7)
+                                + rng.normal(0, 0.4, n)).astype(np.float32),
+    }, index=times)
+
+
+def generate_mid_freq_data(origin, duration_s):
+    """10 Hz — engine & vehicle dynamics under Engine/ and Vehicle/ groups."""
+    rng = np.random.default_rng(20)
+    n = duration_s * 10
+    times = pd.date_range(origin, periods=n, freq="100ms")
+    t = np.linspace(0, duration_s, n)
+
+    # RPM follows a repeating accel/brake pattern per ~12 s lap
+    lap_phase = (t % 12) / 12
+    rpm = 5000 + 13000 * np.where(
+        lap_phase < 0.7, lap_phase / 0.7, (1 - lap_phase) / 0.3,
+    )
+
+    return pd.DataFrame({
+        "Engine/RPM":            rpm.astype(np.float32),
+        "Engine/OilTemp":        (95 + 8 * np.sin(2 * np.pi * t / 80)
+                                  + rng.normal(0, 0.5, n)).astype(np.float32),
+        "Engine/WaterTemp":      (88 + 5 * np.sin(2 * np.pi * t / 60)
+                                  + rng.normal(0, 0.3, n)).astype(np.float32),
+        "Engine/OilPressure":    (4.5 + 0.5 * np.sin(2 * np.pi * t / 40)
+                                  + rng.normal(0, 0.05, n)).astype(np.float32),
+        "Vehicle/Speed":         np.clip(rpm / 60, 50, 340).astype(np.float32),
+        "Vehicle/SteerAng":      (18 * np.sin(2 * np.pi * t / 5)
+                                  * np.sin(2 * np.pi * t / 30)).astype(np.float32),
+        "Vehicle/ThrottlePos":   np.clip(
+            np.where(lap_phase < 0.7, lap_phase / 0.7, 0) * 100
+            + rng.normal(0, 2, n), 0, 100,
+        ).astype(np.float32),
+        "Vehicle/BrakePressure": np.clip(
+            np.where(lap_phase > 0.7, (lap_phase - 0.7) / 0.3, 0) * 35,
+            0, 35,
+        ).astype(np.float32),
+    }, index=times)
+
+
+def generate_low_freq_data(origin, duration_s):
+    """1 Hz — strategy & aero under Strategy/ and Aero/ groups."""
+    rng = np.random.default_rng(30)
+    n = duration_s
+    times = pd.date_range(origin, periods=n, freq="1s")
+    t = np.linspace(0, duration_s, n)
+    return pd.DataFrame({
+        "Strategy/FuelKg":    np.linspace(110, 85, n).astype(np.float32),
+        "Strategy/TyreDeg":   np.clip(
+            np.linspace(0, 15, n) + rng.normal(0, 0.5, n), 0, 100,
+        ).astype(np.float32),
+        "Strategy/ERSEnergy": (4000 - 1500 * np.abs(
+            np.sin(2 * np.pi * t / 24),
+        )).astype(np.float32),
+        "Aero/DragCoeff":     (0.85 + 0.02 * np.sin(2 * np.pi * t / 40)
+                               + rng.normal(0, 0.002, n)).astype(np.float32),
+        "Aero/DownforceN":    (12000 + 2000 * np.sin(
+            2 * np.pi * t / 30,
+        )).astype(np.float32),
+    }, index=times)
+
+
+def generate_synchro_data(origin, duration_s):
+    """Engine-synchronous crank pressure varying with RPM."""
+    rng = np.random.default_rng(1)
+    events_per_rev = 4
+    base_rpm, peak_rpm = 6000, 14000
+
+    samples, timestamps = [], []
+    t_ns = 0
+    origin_ns = int(timestamp2long(origin))
+    end_ns = int(duration_s * 1e9)
+
+    while t_ns < end_ns:
+        phase = t_ns / end_ns
+        lap_local = (t_ns / 1e9 % 12) / 12
+        rpm = base_rpm + (peak_rpm - base_rpm) * (
+            lap_local / 0.7 if lap_local < 0.7
+            else (1 - lap_local) / 0.3
+        )
+        rps = rpm / 60.0
+        interval_ns = int(1e9 / (rps * events_per_rev))
+        pressure = 30.0 + 25.0 * np.sin(2 * np.pi * phase * 10) + rng.normal(0, 2.0)
+        samples.append(pressure)
+        timestamps.append(origin_ns + t_ns)
+        t_ns += interval_ns
+
+    return np.array(samples, dtype=np.float64), np.array(timestamps, dtype=np.int64)
+
+
+def generate_text_channels(origin, n):
+    """Gear, DRS, TyreCompound, PU Mode at 10 Hz."""
+    times = pd.date_range(origin, periods=n, freq="100ms")
+    rng = np.random.default_rng(2)
+
+    lap_phase = np.array([(i / 10 % 12) / 12 for i in range(n)])
+    gear_map = ["N", "1", "2", "3", "4", "5", "6", "7", "8"]
+    gears = [gear_map[min(int(p * 8) + 1, 8)] if p < 0.7
+             else gear_map[max(int((1 - p) / 0.3 * 8), 1)] for p in lap_phase]
+
+    drs = ["OPEN" if 0.3 < p < 0.6 else "CLOSED" for p in lap_phase]
+
+    compounds = ["SOFT", "MEDIUM", "HARD"]
+    tyre_idx = np.clip(np.arange(n) // (n // 3), 0, 2).astype(int)
+    tyres = [compounds[i] for i in tyre_idx]
+
+    mode_options = ["Deploy", "Harvest", "Balanced", "Qualifying", "Overtake"]
+    modes = [mode_options[rng.integers(0, len(mode_options))] for _ in range(n)]
+
+    return times, gears, drs, tyres, modes
+
+
+# ── Event generators (one per severity) ──────────────────────────────
+
+def generate_lockup_events(origin):
+    """HIGH severity — brake lockups."""
+    rng = np.random.default_rng(3)
+    n = 8
+    offsets = np.sort(rng.uniform(5, SESSION_DURATION_S - 5, size=n))
+    return pd.DataFrame({
+        "timestamp": [origin + pd.Timedelta(seconds=float(t)) for t in offsets],
+        "Status": [f"LOCKUP-{i+1:02d}" for i in range(n)],
+        "BrakePressure": rng.uniform(25.0, 40.0, size=n).round(1),
+        "WheelSlip": rng.uniform(0.05, 0.25, size=n).round(3),
+        "Speed": rng.uniform(150.0, 310.0, size=n).round(1),
+    })
+
+
+def generate_flag_events(origin):
+    """MEDIUM severity — track flags."""
+    flags = [
+        (15.0, "YELLOW-S1"),  (18.0, "GREEN"),
+        (52.0, "YELLOW-S3"),  (57.0, "GREEN"),
+        (85.0, "VSC-DEPLOYED"), (95.0, "VSC-ENDING"), (97.0, "GREEN"),
+    ]
+    return pd.DataFrame({
+        "timestamp": [origin + pd.Timedelta(seconds=t) for t, _ in flags],
+        "Status": [s for _, s in flags],
+        "Sector": [1.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0],
+    })
+
+
+def generate_telemetry_events(origin):
+    """LOW severity — informational telemetry notices."""
+    events = [
+        (10.0,  "TYRE-PRES-LOW",  21.5),
+        (30.0,  "ERS-LIMIT",      3950.0),
+        (48.0,  "FUEL-SAVE-ON",   2.1),
+        (60.0,  "FUEL-TARGET",    98.2),
+        (75.0,  "BRAKE-WEAR",     18.3),
+        (80.0,  "TEMP-WARNING",   105.3),
+        (100.0, "WIND-CHANGE",    12.5),
+        (115.0, "FUEL-SAVE-OFF",  0.0),
+    ]
+    return pd.DataFrame({
+        "timestamp": [origin + pd.Timedelta(seconds=t) for t, _, _ in events],
+        "Status": [s for _, s, _ in events],
+        "Value": [v for _, _, v in events],
+    })
+
+
+# ── Marker builder ───────────────────────────────────────────────────
+
+def build_markers(origin):
+    """Build a rich set of point and range markers."""
+    # Point markers — pit lane events
+    pit_points = [
+        (2.0,   "Pit Exit"),
+        (55.0,  "Pit Entry"),
+        (58.0,  "Pit Stop — Tyre Change"),
+        (61.0,  "Pit Exit"),
+        (110.0, "Pit Entry"),
+        (113.0, "Pit Stop — Front Wing Adj"),
+        (116.0, "Pit Exit"),
+    ]
+
+    range_markers = []
+
+    # DRS zones for each timed lap
+    for lap_start in LAP_TIMES_S[1:-1]:
+        range_markers.append({
+            "start_time": origin + pd.Timedelta(seconds=lap_start + 3),
+            "end_time":   origin + pd.Timedelta(seconds=lap_start + 6),
+            "label": "DRS Zone 1",
+            "group": "DRS",
+            "description": "Main straight DRS activation",
+        })
+        range_markers.append({
+            "start_time": origin + pd.Timedelta(seconds=lap_start + 8),
+            "end_time":   origin + pd.Timedelta(seconds=lap_start + 10),
+            "label": "DRS Zone 2",
+            "group": "DRS",
+            "description": "Back straight DRS activation",
+        })
+
+    # Virtual Safety Car period
+    range_markers.append({
+        "start_time": origin + pd.Timedelta(seconds=85),
+        "end_time":   origin + pd.Timedelta(seconds=97),
+        "label": "Virtual Safety Car",
+        "group": "RACE_CONTROL",
+        "description": "VSC period — speed delta enforced",
+    })
+
+    # Sector splits for laps 1-4
+    for lap_idx in range(4):
+        lap_start = LAP_TIMES_S[lap_idx + 1]
+        lap_dur = LAP_TIMES_S[lap_idx + 2] - lap_start
+        s1_end = lap_start + lap_dur * 0.30
+        s2_end = lap_start + lap_dur * 0.65
+        s3_end = lap_start + lap_dur
+        for s_num, (s_start, s_end) in enumerate([
+            (lap_start, s1_end), (s1_end, s2_end), (s2_end, s3_end),
+        ], 1):
+            range_markers.append({
+                "start_time": origin + pd.Timedelta(seconds=s_start),
+                "end_time":   origin + pd.Timedelta(seconds=s_end),
+                "label": f"L{lap_idx+1} Sector {s_num}",
+                "group": "SECTORS",
+            })
+
+    return pit_points, range_markers
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Main
+# ═══════════════════════════════════════════════════════════════════════
+
+def main():
+    origin = ORIGIN_T0
+    n_10hz = SESSION_DURATION_S * 10
+
+    # Generate all data up front
+    hi_df  = generate_high_freq_data(origin, SESSION_DURATION_S)
+    mid_df = generate_mid_freq_data(origin, SESSION_DURATION_S)
+    low_df = generate_low_freq_data(origin, SESSION_DURATION_S)
+    sync_samples, sync_timestamps = generate_synchro_data(origin, SESSION_DURATION_S)
+    text_times, gears, drs, tyres, modes = generate_text_channels(origin, n_10hz)
+    lockup_df    = generate_lockup_events(origin)
+    flag_df      = generate_flag_events(origin)
+    telemetry_df = generate_telemetry_events(origin)
+    pit_points, range_markers = build_markers(origin)
+
+    total_params  = len(hi_df.columns) + len(mid_df.columns) + len(low_df.columns)
+    total_events  = len(lockup_df) + len(flag_df) + len(telemetry_df)
+    total_markers = len(pit_points) + len(range_markers)
+    groups = sorted(set(
+        c.split("/")[0] for df in [hi_df, mid_df, low_df] for c in df.columns
+    ))
+
+    print(f"\n{'=' * 68}")
+    print("  Pandlas Complete Showcase")
+    print(f"{'=' * 68}")
+    print(f"  Backend:      {BACKEND}")
+    print(f"  Duration:     {SESSION_DURATION_S} s ({SESSION_DURATION_S / 60:.0f} min)")
+    print(f"  Row data:     {total_params} params in {len(groups)} groups "
+          f"({', '.join(groups)})")
+    print(f"    100 Hz:     {len(hi_df.columns)} params · "
+          f"{len(hi_df):,} rows")
+    print(f"     10 Hz:     {len(mid_df.columns)} params · "
+          f"{len(mid_df):,} rows")
+    print(f"      1 Hz:     {len(low_df.columns)} params · "
+          f"{len(low_df):,} rows")
+    print(f"  Synchro:      {len(sync_samples):,} samples (crank pressure)")
+    print(f"  Text:         4 channels (Gear, DRS, Tyre, PU Mode)")
+    print(f"  Events:       {total_events} ({len(lockup_df)} high + "
+          f"{len(flag_df)} medium + {len(telemetry_df)} low)")
+    print(f"  Laps:         {len(LAP_NAMES)}")
+    print(f"  Markers:      {total_markers} ({len(pit_points)} point + "
+          f"{len(range_markers)} range)")
+    print(f"  Details:      {len(SESSION_DETAILS)} keys")
+    print(f"  Origin:       {ORIGIN_T0}")
+    print(f"{'=' * 68}\n")
+
+    t0 = time.perf_counter()
+
+    with open_connection("w", "Pandlas Showcase") as session:
+
+        # ── 1. Session details ────────────────────────────────────────
+        set_session_details(session, SESSION_DETAILS)
+        print("  ✓ Session details set")
+
+        # ── 2. Multi-rate grouped row data ────────────────────────────
+        for df_band, label in [
+            (hi_df, "100 Hz"), (mid_df, "10 Hz"), (low_df, "1 Hz"),
+        ]:
+            df_band.atlas.parameter_group_separator = "/"
+            df_band.atlas.to_atlas_session(session)
+            print(f"  ✓ Row data: {label} — "
+                  f"{len(df_band.columns)} params, {len(df_band):,} rows")
+
+        # ── 3. Laps (10 laps, rename first) ──────────────────────────
+        for ts, name in zip(LAP_TIMES_S[:-1], LAP_NAMES):
+            add_lap(session, origin + pd.Timedelta(seconds=ts), lap_name=name)
+        update_lap(session, 0, new_name="Installation Lap")
+        print(f"  ✓ {len(LAP_NAMES)} laps (Out Lap → Installation Lap)")
+
+        # ── 4. Markers ───────────────────────────────────────────────
+        for ts, label in pit_points:
+            add_point_marker(session, origin + pd.Timedelta(seconds=ts), label)
+        add_markers_batch(session, range_markers)
+        print(f"  ✓ {total_markers} markers "
+              f"({len(pit_points)} point + {len(range_markers)} range)")
+
+        # ── 5. Synchro data ──────────────────────────────────────────
+        add_synchro_data(
+            session,
+            parameter_name="CrankPressure",
+            app_group="EngineSync",
+            samples=sync_samples,
+            timestamps=sync_timestamps,
+            unit="bar",
+            description="Crank angle pressure",
+        )
+        print(f"  ✓ Synchro: {len(sync_samples):,} samples")
+
+        # ── 6. Text channels ─────────────────────────────────────────
+        text_defs = [
+            ("Gear",         gears, "DriverInputs", "Current gear"),
+            ("DRS",          drs,   "DriverInputs", "DRS flap state"),
+            ("TyreCompound", tyres, "Strategy",     "Current tyre compound"),
+            ("PUMode",       modes, "Powertrain",   "Power unit mode"),
+        ]
+        for name, vals, grp, desc in text_defs:
+            add_text_channel(
+                session, parameter_name=name, values=vals,
+                timestamps=text_times, application_group=grp,
+                description=desc,
+            )
+        print(f"  ✓ Text channels: {len(text_defs)} "
+              f"({', '.join(n for n, *_ in text_defs)})")
+
+        # ── 7. Events — all severity levels ──────────────────────────
+        n_hi = add_events(
+            session, lockup_df, status_column="Status",
+            description="Brake Lockup", priority="high",
+            application_group="BrakeApp",
+        )
+        n_med = add_events(
+            session, flag_df, status_column="Status",
+            description="Track Flags", priority="medium",
+            application_group="RaceControl",
+        )
+        n_lo = add_events(
+            session, telemetry_df, status_column="Status",
+            description="Telemetry Info", priority="low",
+            application_group="Telemetry",
+        )
+        print(f"  ✓ Events: {n_hi} high + {n_med} medium + {n_lo} low")
+
+    elapsed = time.perf_counter() - t0
+
+    # ── Summary ──────────────────────────────────────────────────────
+    print(f"\n{'=' * 68}")
+    print("  RESULTS")
+    print(f"{'=' * 68}")
+    print(f"  Total write time:  {elapsed:.3f} s")
+    print(f"  Features used:     7 / 7")
+    print(f"    • Session details      {len(SESSION_DETAILS)} keys")
+    print(f"    • Grouped row data     {total_params} params, "
+          f"{len(groups)} groups, 3 rates")
+    print(f"    • Laps                 {len(LAP_NAMES)} laps (1 renamed)")
+    print(f"    • Markers              {total_markers} "
+          f"({len(pit_points)} point + {len(range_markers)} range)")
+    print(f"    • Synchro data         {len(sync_samples):,} samples")
+    print(f"    • Text channels        {len(text_defs)}")
+    print(f"    • Events               {total_events} "
+          f"(high / medium / low)")
+    print(f"{'=' * 68}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/event_logging.py
+++ b/example/event_logging.py
@@ -1,0 +1,167 @@
+"""Event logging example for Pandlas.
+
+Demonstrates how to write discrete events (lockups, flags, pit stops, etc.)
+to an ATLAS session from a Pandas DataFrame using ``add_events()``.
+
+Each row in the DataFrame becomes one ATLAS event.  Every numeric column
+(besides the timestamp) is stored as an event value visible in ATLAS.
+
+Usage:
+    python event_logging.py
+"""
+
+import logging
+import numpy as np
+import pandas as pd
+
+from pandlas import SQLiteConnection, SQLRaceDBConnection
+from pandlas import add_events, add_lap, set_session_details
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# ── Configuration ────────────────────────────────────────────────────────
+BACKEND = "sqlserver"
+
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\EventLogging.ssndb"
+
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+SESSION_DURATION_S = 60
+SAMPLE_RATE_MS = 100  # 10 Hz
+TOTAL_ROWS = int(SESSION_DURATION_S * 1000 / SAMPLE_RATE_MS)
+
+ORIGIN_T0 = pd.Timestamp.now()
+
+
+def open_connection(mode, identifier="", key=None):
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, session_key=key, mode=mode,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, session_key=key, mode=mode,
+    )
+
+
+def build_lockup_events(origin: pd.Timestamp, n: int = 8) -> pd.DataFrame:
+    """Simulate brake lockup events at random times."""
+    rng = np.random.default_rng(42)
+    offsets = np.sort(rng.uniform(2, SESSION_DURATION_S - 2, size=n))
+    timestamps = [origin + pd.Timedelta(seconds=float(t)) for t in offsets]
+    return pd.DataFrame({
+        "timestamp": timestamps,
+        "Status": [f"LK-{i + 1:03d}" for i in range(n)],
+        "BrakePressure": rng.uniform(20.0, 40.0, size=n).round(1),
+        "WheelSlip": rng.uniform(0.05, 0.25, size=n).round(3),
+        "Speed": rng.uniform(120.0, 310.0, size=n).round(1),
+    })
+
+def build_flag_events(origin: pd.Timestamp) -> pd.DataFrame:
+    """Simulate track flag events."""
+    flags = [
+        (5.0,  "YEL-S1",  1.0),   # yellow flag at 5 s, sector 1
+        (12.0, "YEL-S3",  3.0),   # yellow flag at 12 s, sector 3
+        (25.0, "GREEN",    0.0),   # green flag at 25 s (all clear)
+        (40.0, "YEL-S2",  2.0),   # yellow flag at 40 s, sector 2
+        (55.0, "GREEN",    0.0),   # green flag at 55 s
+    ]
+    return pd.DataFrame({
+        "timestamp": [origin + pd.Timedelta(seconds=t) for t, _, _ in flags],
+        "Status": [s for _, s, _ in flags],
+        "FlagType": [float(f) for _, _, f in flags],
+    })
+
+
+def build_pitstop_events(origin: pd.Timestamp) -> pd.DataFrame:
+    """Simulate pit stop events."""
+    return pd.DataFrame({
+        "timestamp": [
+            origin + pd.Timedelta(seconds=28.0),
+            origin + pd.Timedelta(seconds=50.0),
+        ],
+        "Status": ["PIT-01", "PIT-02"],
+        "StopDuration": [2.4, 2.1],
+        "TyreSet": [2.0, 3.0],
+        "FuelAdded": [0.0, 0.0],
+    })
+
+
+def main():
+    origin = ORIGIN_T0
+
+    lockups = build_lockup_events(origin)
+    flags = build_flag_events(origin)
+    pitstops = build_pitstop_events(origin)
+
+    print(f"\n{'=' * 60}")
+    print("  Pandlas Event Logging Example")
+    print(f"{'=' * 60}")
+    print(f"  Backend:    {BACKEND}")
+    print(f"  Duration:   {SESSION_DURATION_S} s")
+    print(f"  Lockups:    {len(lockups)} events (3 values each)")
+    print(f"  Flags:      {len(flags)} events (1 value each)")
+    print(f"  Pit stops:  {len(pitstops)} events (3 values each)")
+    print(f"  Origin:     {ORIGIN_T0}")
+    print(f"{'=' * 60}\n")
+
+    with open_connection("w", "Event Logging Example") as session:
+
+        # Optional: add session metadata
+        set_session_details(session, {
+            "Driver": "Lando Norris",
+            "Circuit": "Silverstone",
+            "Event": "British GP 2026",
+        })
+
+        # Write a simple row-data signal so the session has a time range
+        times = pd.date_range(
+            origin, periods=TOTAL_ROWS,
+            freq=f"{SAMPLE_RATE_MS}ms",
+        )
+        speed = np.linspace(0, 300, TOTAL_ROWS).astype(np.float32)
+        df = pd.DataFrame({"vCar": speed}, index=times)
+        df.atlas.to_atlas_session(session)
+
+        # Add a lap so events are contextualised
+        add_lap(session, origin + pd.Timedelta(seconds=30), lap_name="Lap 1")
+
+        # ── Write events ─────────────────────────────────────────────
+        print("Phase 1: Writing events ...\n")
+
+        n1 = add_events(
+            session, lockups,
+            status_column="Status",
+            description="Brake Lockup",
+            priority="high",
+            application_group="BrakeApp",
+        )
+        print(f"  ✓ Lockup events:   {n1}")
+
+        n2 = add_events(
+            session, flags,
+            status_column="Status",
+            description="Track Flags",
+            priority="medium",
+            application_group="RaceControl",
+        )
+        print(f"  ✓ Flag events:     {n2}")
+
+        n3 = add_events(
+            session, pitstops,
+            status_column="Status",
+            description="Pit Stops",
+            priority="low",
+            application_group="Strategy",
+        )
+        print(f"  ✓ Pit stop events: {n3}")
+
+    # ── Summary ──────────────────────────────────────────────────────
+    print(f"\n{'=' * 60}")
+    print(f"  Total events written: {n1 + n2 + n3}")
+    print(f"  Event groups: BrakeApp, RaceControl, Strategy")
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/live_crypto.py
+++ b/example/live_crypto.py
@@ -1,0 +1,332 @@
+"""Live Crypto Ticker — Binance Public API
+==========================================
+
+Streams real-time prices for 20 crypto assets into an ATLAS live session.
+Uses the Binance public REST API (no key, no auth required).
+
+Features demonstrated:
+  - Live session (recorder mode) with 100 Hz streaming
+  - 20 parameters grouped by market cap tier
+  - Events: price spike alerts (high), new 24h high/low (medium),
+            volume surge (low)
+  - Point markers on significant price moves
+  - Session details with market metadata
+
+Data source: https://api.binance.com (public, no auth)
+
+Usage:
+    python live_crypto.py
+"""
+
+import time
+import logging
+import numpy as np
+import pandas as pd
+import requests
+
+from pandlas import (
+    SQLiteConnection,
+    SQLRaceDBConnection,
+    add_point_marker,
+    add_events,
+    set_session_details,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Configuration
+# ═══════════════════════════════════════════════════════════════════════
+BACKEND = "sqlserver"
+
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\LiveCrypto.ssndb"
+
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+POLL_INTERVAL_S = 5        # API poll cadence
+STREAM_INTERVAL_S = 0.01  # 100 Hz to ATLAS
+SESSION_DURATION_S = 120  # 2 minutes
+
+# 20 assets grouped by tier
+SYMBOLS = {
+    "Majors": ["BTCUSDT", "ETHUSDT", "BNBUSDT", "SOLUSDT", "XRPUSDT"],
+    "MidCap": ["DOGEUSDT", "ADAUSDT", "AVAXUSDT", "DOTUSDT", "LINKUSDT"],
+    "AltL1":  ["MATICUSDT", "NEARUSDT", "ATOMUSDT", "ALGOUSDT", "FILUSDT"],
+    "Others": ["SHIBUSDT", "LTCUSDT", "TRXUSDT", "UNIUSDT", "XLMUSDT"],
+}
+
+ALL_SYMBOLS = [s for group in SYMBOLS.values() for s in group]
+
+# Units for each parameter (Group/Asset → unit)
+PARAM_UNITS = {
+    f"{group}/{sym.replace('USDT', '')}": "USD"
+    for group, syms in SYMBOLS.items()
+    for sym in syms
+}
+
+# Thresholds
+PRICE_SPIKE_PCT = 0.5    # % move between polls triggers HIGH event
+VOLUME_SURGE_MULT = 1.5  # volume jump multiplier triggers LOW event
+
+SESSION_DETAILS = {
+    "Source": "Binance Public API",
+    "Assets": str(len(ALL_SYMBOLS)),
+    "Quote": "USDT",
+    "Comment": "Live crypto ticker — Pandlas showcase",
+}
+
+# Binance endpoints
+PRICE_URL = "https://api.binance.com/api/v3/ticker/price"
+TICKER_24H_URL = "https://api.binance.com/api/v3/ticker/24hr"
+
+
+def open_connection(identifier):
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, mode="w", recorder=True,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, mode="w", recorder=True,
+    )
+
+
+def clean_name(symbol: str) -> str:
+    """BTCUSDT → BTC"""
+    return symbol.replace("USDT", "")
+
+
+def fetch_prices() -> dict | None:
+    """Fetch current prices for all symbols. Returns {symbol: price}."""
+    try:
+        import json
+        sym_str = json.dumps(ALL_SYMBOLS, separators=(",", ":"))
+        url = f"{PRICE_URL}?symbols={sym_str}"
+        resp = requests.get(url, timeout=5)
+        if resp.status_code == 200:
+            return {item["symbol"]: float(item["price"]) for item in resp.json()}
+        else:
+            logger.warning("Price API returned %d: %s", resp.status_code, resp.text[:100])
+    except Exception as exc:
+        logger.warning("Price API failed: %s", exc)
+    return None
+
+
+def fetch_24h_stats() -> dict | None:
+    """Fetch 24h stats for all symbols. Returns {symbol: {...}}."""
+    try:
+        resp = requests.get(TICKER_24H_URL, timeout=5)
+        if resp.status_code == 200:
+            data = resp.json()
+            return {
+                item["symbol"]: {
+                    "high": float(item["highPrice"]),
+                    "low": float(item["lowPrice"]),
+                    "change_pct": float(item["priceChangePercent"]),
+                    "volume": float(item["quoteVolume"]),
+                }
+                for item in data
+                if item["symbol"] in ALL_SYMBOLS
+            }
+    except Exception as exc:
+        logger.warning("24h stats API failed: %s", exc)
+    return None
+
+
+def main():
+    print(f"\n{'=' * 64}")
+    print("  📈  Pandlas Live Crypto Ticker")
+    print(f"{'=' * 64}")
+    print(f"  Backend:      {BACKEND}")
+    print(f"  Assets:       {len(ALL_SYMBOLS)} crypto pairs")
+    for group, symbols in SYMBOLS.items():
+        names = ", ".join(clean_name(s) for s in symbols)
+        print(f"    {group:10s}  {names}")
+    print(f"  Poll rate:    every {POLL_INTERVAL_S} s (API)")
+    print(f"  Stream rate:  {1/STREAM_INTERVAL_S:.0f} Hz to ATLAS")
+    print(f"  Duration:     {SESSION_DURATION_S} s")
+    print(f"  Spike alert:  >{PRICE_SPIKE_PCT}% move between polls")
+    print(f"  API:          Binance (public, no auth)")
+    print(f"{'=' * 64}\n")
+
+    # Fetch initial 24h stats for baseline
+    stats_24h = fetch_24h_stats() or {}
+
+    # Event accumulators
+    spike_events = []
+    high_low_events = []
+    info_events = []
+    marker_log = []
+
+    prev_prices = {}
+    last_prices = None
+    sample_count = 0
+
+    with open_connection("Crypto Ticker") as session:
+
+        set_session_details(session, SESSION_DETAILS)
+        print("  Session is LIVE — open in ATLAS to watch data stream in.\n")
+
+        t_start = time.time()
+        next_poll = t_start
+
+        while (time.time() - t_start) < SESSION_DURATION_S:
+            now_wall = time.time()
+
+            # ── Poll API at cadence ───────────────────────────────────
+            if now_wall >= next_poll:
+                prices = fetch_prices()
+                if prices is not None:
+                    now_ts = pd.Timestamp.now()
+
+                    # Build grouped row: Group/Asset → price
+                    last_prices = {}
+                    for group, symbols in SYMBOLS.items():
+                        for sym in symbols:
+                            col = f"{group}/{clean_name(sym)}"
+                            last_prices[col] = prices.get(sym, 0.0)
+
+                    elapsed = now_wall - t_start
+                    btc = prices.get("BTCUSDT", 0)
+                    eth = prices.get("ETHUSDT", 0)
+                    sol = prices.get("SOLUSDT", 0)
+                    print(f"  [{elapsed:5.0f}s]  BTC ${btc:,.2f}  "
+                          f"ETH ${eth:,.2f}  SOL ${sol:,.2f}  "
+                          f"({len(prices)} assets)")
+
+                    # ── Detect events ─────────────────────────────────
+                    for sym in ALL_SYMBOLS:
+                        name = clean_name(sym)
+                        price = prices.get(sym, 0)
+
+                        if sym in prev_prices and prev_prices[sym] > 0:
+                            pct_change = (
+                                (price - prev_prices[sym])
+                                / prev_prices[sym] * 100
+                            )
+
+                            # HIGH: price spike
+                            if abs(pct_change) > PRICE_SPIKE_PCT:
+                                direction = "UP" if pct_change > 0 else "DOWN"
+                                spike_events.append({
+                                    "timestamp": now_ts,
+                                    "Status": f"{name}-{direction}-"
+                                              f"{abs(pct_change):.2f}%",
+                                    "PctChange": abs(pct_change),
+                                    "Price": price,
+                                })
+                                add_point_marker(
+                                    session, now_ts,
+                                    f"⚡ {name} {direction} "
+                                    f"{abs(pct_change):.2f}%",
+                                )
+                                marker_log.append(
+                                    f"{name} {direction} {abs(pct_change):.2f}%"
+                                )
+
+                        # MEDIUM: new 24h high or low
+                        if sym in stats_24h:
+                            s = stats_24h[sym]
+                            if price > s["high"]:
+                                high_low_events.append({
+                                    "timestamp": now_ts,
+                                    "Status": f"{name}-NEW-24H-HIGH",
+                                    "Price": price,
+                                })
+                                add_point_marker(
+                                    session, now_ts,
+                                    f"🔺 {name} new 24h high ${price:,.4f}",
+                                )
+                                marker_log.append(
+                                    f"{name} new 24h high"
+                                )
+                                stats_24h[sym]["high"] = price
+                            elif price < s["low"]:
+                                high_low_events.append({
+                                    "timestamp": now_ts,
+                                    "Status": f"{name}-NEW-24H-LOW",
+                                    "Price": price,
+                                })
+                                add_point_marker(
+                                    session, now_ts,
+                                    f"🔻 {name} new 24h low ${price:,.4f}",
+                                )
+                                marker_log.append(
+                                    f"{name} new 24h low"
+                                )
+                                stats_24h[sym]["low"] = price
+
+                    prev_prices = dict(prices)
+
+                next_poll = now_wall + POLL_INTERVAL_S
+
+            # ── Stream last known values at 100 Hz ────────────────────
+            if last_prices is not None:
+                now_ts = pd.Timestamp.now()
+                df = pd.DataFrame(
+                    [{k: np.float32(v) for k, v in last_prices.items()}],
+                    index=pd.DatetimeIndex([now_ts]),
+                )
+                df.atlas.parameter_group_separator = "/"
+                df.atlas.units = PARAM_UNITS
+                df.atlas.to_atlas_session(session, show_progress_bar=False)
+                sample_count += 1
+
+            time.sleep(STREAM_INTERVAL_S)
+
+        # ── Write collected events ────────────────────────────────────
+        total_events = 0
+        if spike_events:
+            n = add_events(
+                session, pd.DataFrame(spike_events),
+                status_column="Status",
+                description="Price Spike",
+                priority="high",
+                application_group="Market",
+            )
+            total_events += n
+
+        if high_low_events:
+            n = add_events(
+                session, pd.DataFrame(high_low_events),
+                status_column="Status",
+                description="24h High/Low",
+                priority="medium",
+                application_group="Market",
+            )
+            total_events += n
+
+        if info_events:
+            n = add_events(
+                session, pd.DataFrame(info_events),
+                status_column="Status",
+                description="Volume Surge",
+                priority="low",
+                application_group="Market",
+            )
+            total_events += n
+
+    # ── Summary ──────────────────────────────────────────────────────
+    print(f"\n{'=' * 64}")
+    print("  SESSION COMPLETE")
+    print(f"{'=' * 64}")
+    print(f"  Samples:    {sample_count:,} rows streamed to ATLAS")
+    print(f"  Assets:     {len(ALL_SYMBOLS)} crypto pairs in 4 groups")
+    print(f"  Markers:    {len(marker_log)}")
+    for m in marker_log[:10]:
+        print(f"    • {m}")
+    if len(marker_log) > 10:
+        print(f"    ... and {len(marker_log) - 10} more")
+    print(f"  Events:     {total_events} total")
+    if spike_events:
+        print(f"    HIGH:     {len(spike_events)} price spikes")
+    if high_low_events:
+        print(f"    MEDIUM:   {len(high_low_events)} new 24h highs/lows")
+    if info_events:
+        print(f"    LOW:      {len(info_events)} volume surges")
+    print(f"{'=' * 64}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/live_weather.py
+++ b/example/live_weather.py
@@ -1,0 +1,314 @@
+"""Live Weather Station — Silverstone Circuit
+==============================================
+
+Streams real-time weather data from the Open-Meteo API into an ATLAS live
+session for 2 minutes.  No API key required.
+
+Features demonstrated:
+  - Live session (recorder mode)
+  - Real-time row data streaming
+  - Automatic event generation (wind gusts, rain, temperature alerts)
+  - Point markers on weather transitions
+  - Session details
+
+Data source: https://open-meteo.com (free, no auth)
+
+Usage:
+    python live_weather.py
+"""
+
+import time
+import logging
+import numpy as np
+import pandas as pd
+import requests
+
+from pandlas import (
+    SQLiteConnection,
+    SQLRaceDBConnection,
+    add_point_marker,
+    add_events,
+    set_session_details,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Configuration
+# ═══════════════════════════════════════════════════════════════════════
+BACKEND = "sqlserver"
+
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\LiveWeather.ssndb"
+
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+# Silverstone Circuit coordinates
+LATITUDE = 52.0705
+LONGITUDE = -1.0165
+LOCATION_NAME = "Silverstone"
+
+# Open-Meteo current weather endpoint (free, no key)
+API_URL = (
+    f"https://api.open-meteo.com/v1/forecast"
+    f"?latitude={LATITUDE}&longitude={LONGITUDE}"
+    f"&current=temperature_2m,relative_humidity_2m,apparent_temperature,"
+    f"precipitation,rain,wind_speed_10m,wind_direction_10m,"
+    f"wind_gusts_10m,surface_pressure,cloud_cover"
+    f"&timezone=Europe%2FLondon"
+)
+
+POLL_INTERVAL_S = 10       # seconds between API calls
+STREAM_INTERVAL_S = 0.01  # seconds between ATLAS writes (100 Hz)
+SESSION_DURATION_S = 120  # 2 minutes
+
+# Thresholds for automatic events and markers
+WIND_GUST_THRESHOLD_KMH = 15.0
+RAIN_THRESHOLD_MM = 0.1
+TEMP_DROP_THRESHOLD_C = 2.0
+
+SESSION_DETAILS = {
+    "Location": LOCATION_NAME,
+    "Latitude": str(LATITUDE),
+    "Longitude": str(LONGITUDE),
+    "Source": "Open-Meteo API",
+    "Comment": "Live weather streaming demo",
+}
+
+# Columns we care about from the API
+WEATHER_FIELDS = [
+    "temperature_2m",
+    "relative_humidity_2m",
+    "apparent_temperature",
+    "precipitation",
+    "rain",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_gusts_10m",
+    "surface_pressure",
+    "cloud_cover",
+]
+
+WEATHER_UNITS = {
+    "temperature_2m":       "degC",
+    "relative_humidity_2m": "%",
+    "apparent_temperature": "degC",
+    "precipitation":        "mm",
+    "rain":                 "mm",
+    "wind_speed_10m":       "km/h",
+    "wind_direction_10m":   "deg",
+    "wind_gusts_10m":       "km/h",
+    "surface_pressure":     "hPa",
+    "cloud_cover":          "%",
+}
+
+
+def open_connection(identifier):
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, mode="w", recorder=True,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, mode="w", recorder=True,
+    )
+
+
+def fetch_weather() -> dict | None:
+    """Fetch current weather from Open-Meteo. Returns None on failure."""
+    try:
+        resp = requests.get(API_URL, timeout=5)
+        if resp.status_code == 200:
+            return resp.json()["current"]
+    except Exception as exc:
+        logger.warning("API request failed: %s", exc)
+    return None
+
+
+def main():
+    print(f"\n{'=' * 64}")
+    print("  ☁️  Pandlas Live Weather Station")
+    print(f"{'=' * 64}")
+    print(f"  Location:     {LOCATION_NAME} ({LATITUDE}, {LONGITUDE})")
+    print(f"  Backend:      {BACKEND}")
+    print(f"  Poll rate:    every {POLL_INTERVAL_S} s (API)")
+    print(f"  Stream rate:  {1/STREAM_INTERVAL_S:.0f} Hz to ATLAS")
+    print(f"  Duration:     {SESSION_DURATION_S} s")
+    print(f"  API:          Open-Meteo (free, no key)")
+    print(f"  Events on:    gusts > {WIND_GUST_THRESHOLD_KMH} km/h, "
+          f"rain > {RAIN_THRESHOLD_MM} mm")
+    print(f"{'=' * 64}\n")
+
+    # Collect events for batch write at end
+    gust_events = []
+    rain_events = []
+    info_events = []
+    marker_log = []
+
+    prev_rain = 0.0
+    prev_temp = None
+    prev_gust_above = False
+    sample_count = 0
+    last_row = None  # last known weather values
+
+    with open_connection(f"Weather {LOCATION_NAME}") as session:
+
+        set_session_details(session, SESSION_DETAILS)
+        print("  Session is LIVE — open in ATLAS to watch data stream in.\n")
+
+        t_start = time.time()
+        next_poll = t_start  # poll immediately on first iteration
+
+        while (time.time() - t_start) < SESSION_DURATION_S:
+            now_wall = time.time()
+
+            # ── Poll API at POLL_INTERVAL_S cadence ───────────────────
+            if now_wall >= next_poll:
+                weather = fetch_weather()
+                if weather is not None:
+                    last_row = {
+                        field: float(weather.get(field, 0))
+                        for field in WEATHER_FIELDS
+                    }
+
+                    # Event / marker detection only on fresh API data
+                    temp = last_row["temperature_2m"]
+                    gusts = last_row["wind_gusts_10m"]
+                    rain = last_row["precipitation"]
+                    cloud = last_row["cloud_cover"]
+                    now_ts = pd.Timestamp.now()
+
+                    elapsed = now_wall - t_start
+                    print(f"  [{elapsed:5.0f}s] {temp:.1f}°C  "
+                          f"💨 {last_row['wind_speed_10m']:.1f} km/h "
+                          f"(gusts {gusts:.1f})  "
+                          f"🌧️ {rain:.1f} mm  ☁️ {cloud:.0f}%")
+
+                    # ── Wind gust event (HIGH) — edge-triggered ───────
+                    gust_above = gusts > WIND_GUST_THRESHOLD_KMH
+                    if gust_above and not prev_gust_above:
+                        gust_events.append({
+                            "timestamp": now_ts,
+                            "Status": f"GUST-{gusts:.0f}KMH",
+                            "WindGust": gusts,
+                            "WindDir": last_row["wind_direction_10m"],
+                        })
+                        add_point_marker(session, now_ts,
+                                         f"⚠ Gust {gusts:.0f} km/h")
+                        marker_log.append(f"Gust {gusts:.0f} km/h")
+                    elif not gust_above and prev_gust_above:
+                        gust_events.append({
+                            "timestamp": now_ts,
+                            "Status": "GUST-CLEAR",
+                            "WindGust": gusts,
+                            "WindDir": last_row["wind_direction_10m"],
+                        })
+                        add_point_marker(session, now_ts, "✓ Gusts subsided")
+                        marker_log.append("Gusts subsided")
+                    prev_gust_above = gust_above
+
+                    # ── Rain onset/stop (MEDIUM) ──────────────────────
+                    if rain > RAIN_THRESHOLD_MM and prev_rain <= RAIN_THRESHOLD_MM:
+                        rain_events.append({
+                            "timestamp": now_ts,
+                            "Status": "RAIN-START",
+                            "Precipitation": rain,
+                        })
+                        add_point_marker(session, now_ts, "🌧 Rain Started")
+                        marker_log.append("Rain started")
+                    elif rain <= RAIN_THRESHOLD_MM and prev_rain > RAIN_THRESHOLD_MM:
+                        rain_events.append({
+                            "timestamp": now_ts,
+                            "Status": "RAIN-STOP",
+                            "Precipitation": rain,
+                        })
+                        add_point_marker(session, now_ts, "☀ Rain Stopped")
+                        marker_log.append("Rain stopped")
+                    prev_rain = rain
+
+                    # ── Temperature shift (LOW) ───────────────────────
+                    if prev_temp is not None:
+                        delta = abs(temp - prev_temp)
+                        if delta >= TEMP_DROP_THRESHOLD_C:
+                            direction = "RISE" if temp > prev_temp else "DROP"
+                            info_events.append({
+                                "timestamp": now_ts,
+                                "Status": f"TEMP-{direction}-{delta:.1f}C",
+                                "Value": temp,
+                            })
+                            add_point_marker(
+                                session, now_ts,
+                                f"🌡 Temp {direction.lower()} {delta:.1f}°C",
+                            )
+                            marker_log.append(
+                                f"Temp {direction.lower()} {delta:.1f}°C"
+                            )
+                    prev_temp = temp
+
+                next_poll = now_wall + POLL_INTERVAL_S
+
+            # ── Stream last known values at 100 Hz ────────────────────
+            if last_row is not None:
+                now_ts = pd.Timestamp.now()
+                df = pd.DataFrame(
+                    [last_row],
+                    index=pd.DatetimeIndex([now_ts]),
+                )
+                df.atlas.units = WEATHER_UNITS
+                df.atlas.to_atlas_session(session, show_progress_bar=False)
+                sample_count += 1
+
+            time.sleep(STREAM_INTERVAL_S)
+
+        # ── Write collected events as batch ───────────────────────────
+        total_events = 0
+        if gust_events:
+            n = add_events(
+                session, pd.DataFrame(gust_events),
+                status_column="Status",
+                description="Wind Gusts",
+                priority="high",
+                application_group="Weather",
+            )
+            total_events += n
+
+        if rain_events:
+            n = add_events(
+                session, pd.DataFrame(rain_events),
+                status_column="Status",
+                description="Precipitation",
+                priority="medium",
+                application_group="Weather",
+            )
+            total_events += n
+
+        if info_events:
+            n = add_events(
+                session, pd.DataFrame(info_events),
+                status_column="Status",
+                description="Temperature Shift",
+                priority="low",
+                application_group="Weather",
+            )
+            total_events += n
+
+    # ── Summary ──────────────────────────────────────────────────────
+    print(f"\n{'=' * 64}")
+    print("  SESSION COMPLETE")
+    print(f"{'=' * 64}")
+    print(f"  Samples:    {sample_count} weather readings")
+    print(f"  Markers:    {len(marker_log)}")
+    for m in marker_log:
+        print(f"    • {m}")
+    print(f"  Events:     {total_events} total")
+    if gust_events:
+        print(f"    HIGH:     {len(gust_events)} wind gust alerts")
+    if rain_events:
+        print(f"    MEDIUM:   {len(rain_events)} rain transitions")
+    if info_events:
+        print(f"    LOW:      {len(info_events)} temperature shifts")
+    print(f"{'=' * 64}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/multirate_session.py
+++ b/example/multirate_session.py
@@ -1,0 +1,658 @@
+"""
+Pandlas Performance and Validation Test
+=======================================
+
+Combined test that writes data through pandlas into an ATLAS session and then
+reads it back, validating both correctness and throughput.
+
+Validates:
+  - Float data write and read-back (data integrity)
+  - Custom units per parameter
+  - Custom descriptions per parameter
+  - Custom display format per parameter
+  - Custom display limits per parameter (min/max override)
+  - Custom warning limits per parameter (min/max override)
+  - Default auto-computed limits (from data range)
+  - Multiple parameter groups and application groups
+  - Laps, point markers, and range markers
+
+Performance:
+  - Measures configuration creation time (first batch)
+  - Measures streaming write throughput (samples/s)
+
+Requirements:
+  - ATLAS 10 installed with SQL Race API available
+  - pandlas installed (and able to resolve the ATLAS/SQL Race assemblies)
+
+Usage:
+  Adjust BACKEND, paths, and scale constants below, then run:
+      python performance_test.py
+"""
+
+import sys
+import time
+import logging
+import numpy as np
+import pandas as pd
+
+from pandlas import SQLiteConnection, SQLRaceDBConnection
+from pandlas import add_synchro_data
+from pandlas.utils import timestamp2long
+import pandlas.SqlRace as sr
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ========================= CONFIGURATION =========================
+# Backend: "sqlite" or "sqlserver"
+BACKEND = "sqlserver"
+
+# SQLite settings
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\ValidationTest.ssndb"
+
+# SQL Server settings (only used when BACKEND = "sqlserver")
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+# Scale
+SESSION_DURATION_S = 60  # desired session duration in seconds
+BATCH_DURATION_S = 0.1  # how much wall-time each streaming batch covers
+
+# Parameter rate bands — each entry: (prefix, count, sample_interval_ms)
+# Parameters at different frequencies, as you'd see on a real car.
+RATE_BANDS = [
+    ("F1", 10,    1),     # 1 kHz  — high-speed channels (e.g. vibration)
+    ("F10", 20,  10),     # 100 Hz — medium-speed (e.g. suspension, steering)
+    ("F100", 30, 100),    # 10 Hz  — standard telemetry (e.g. temps, pressures)
+    ("F1000", 40, 1000),  # 1 Hz   — slow channels (e.g. strategy, fuel)
+]
+# =================================================================
+
+ORIGIN_T0 = pd.Timestamp.now()
+
+# Build per-band column names and phase offsets
+BAND_META = {}
+for prefix, count, interval_ms in RATE_BANDS:
+    cols = [f"{prefix}_{i:04d}" for i in range(count)]
+    phases = np.linspace(0.0, 2.0 * np.pi, count, endpoint=False)
+    n_rows = int(SESSION_DURATION_S * 1000 / interval_ms)
+    batch_rows = int(BATCH_DURATION_S * 1000 / interval_ms)
+    BAND_META[prefix] = {
+        "cols": cols,
+        "phases": phases,
+        "interval_ms": interval_ms,
+        "n_rows": n_rows,
+        "batch_rows": max(1, batch_rows),
+        "count": count,
+    }
+
+TOTAL_PARAMS = sum(b["count"] for b in BAND_META.values())
+
+# ---------- Metadata fixtures (applied to the first band) ----------
+_first_prefix = RATE_BANDS[0][0]
+_first_cols = BAND_META[_first_prefix]["cols"]
+CUSTOM_UNITS = {
+    f"{_first_cols[0]}:TestApp": "m/s",
+    f"{_first_cols[1]}:TestApp": "deg",
+    f"{_first_cols[2]}:TestApp": "bar",
+    f"{_first_cols[3]}:TestApp": "rpm",
+    f"{_first_cols[4]}:TestApp": "\u00b0C",
+}
+
+CUSTOM_DESCRIPTIONS = {
+    f"{_first_cols[0]}:TestApp": "Vehicle speed",
+    f"{_first_cols[1]}:TestApp": "Steering angle",
+    f"{_first_cols[2]}:TestApp": "Brake pressure",
+    f"{_first_cols[3]}:TestApp": "Engine speed",
+    f"{_first_cols[4]}:TestApp": "Coolant temperature",
+}
+
+CUSTOM_FORMATS = {
+    f"{_first_cols[0]}:TestApp": "%6.1f",
+    f"{_first_cols[1]}:TestApp": "%7.2f",
+    f"{_first_cols[2]}:TestApp": "%5.3f",
+}
+
+CUSTOM_DISPLAY_LIMITS = {
+    f"{_first_cols[0]}:TestApp": (-100.0, 400.0),
+    f"{_first_cols[1]}:TestApp": (-180.0, 180.0),
+    f"{_first_cols[2]}:TestApp": (0.0, 200.0),
+}
+
+CUSTOM_WARNING_LIMITS = {
+    f"{_first_cols[0]}:TestApp": (-50.0, 370.0),
+    f"{_first_cols[1]}:TestApp": (-170.0, 170.0),
+    f"{_first_cols[2]}:TestApp": (0.0, 180.0),
+}
+
+
+# ---- Synchro (engine-synchronous) signals ----
+# 5 synchro parameters simulating crank-sync sensors at varying RPM.
+# Using 4 events/rev (like a 4-cylinder firing pattern) keeps peak frequency
+# well below the 1 kHz row-data band even at high RPM.
+SYNCHRO_SIGNALS = [
+    ("IgnitionAdv",  "deg",  "Ignition advance angle"),
+    ("CylPressure",  "bar",  "Cylinder pressure"),
+    ("InjDuration",  "ms",   "Injector pulse duration"),
+    ("KnockLevel",   "V",    "Knock sensor voltage"),
+    ("CrankTorque",  "Nm",   "Instantaneous crank torque"),
+]
+SYNCHRO_RPM_IDLE = 800       # idle RPM
+SYNCHRO_RPM_MAX = 8_000      # peak RPM
+SYNCHRO_EVENTS_PER_REV = 4   # events per revolution (e.g. 4-cyl firing)
+SYNCHRO_RPM_CYCLES = 3       # number of idle-max-idle sweeps in the session
+# Frequency range: 800*4/60 ≈ 53 Hz (idle) → 8000*4/60 ≈ 533 Hz (peak)
+
+
+def generate_synchro_signal(
+    start_ns: int,
+    duration_s: float,
+    phase: float = 0.0,
+    rpm_idle: float = SYNCHRO_RPM_IDLE,
+    rpm_max: float = SYNCHRO_RPM_MAX,
+    n_cycles: int = SYNCHRO_RPM_CYCLES,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate a crank-sync signal that spans the full session duration.
+
+    Builds timestamps iteratively from RPM-driven intervals until
+    ``duration_s`` is reached, so the sample count adapts naturally
+    to the RPM profile.
+
+    Returns:
+        (samples, timestamps_ns) tuple.
+    """
+    duration_ns = int(duration_s * 1e9)
+    end_ns = start_ns + duration_ns
+
+    # Over-estimate max possible samples (peak freq × duration + margin)
+    peak_freq = rpm_max * SYNCHRO_EVENTS_PER_REV / 60.0
+    est_max = int(peak_freq * duration_s * 1.2) + 1000
+
+    # Build an RPM profile over normalised time [0,1] → idle-max-idle sweeps
+    t_norm = np.linspace(0.0, 1.0, est_max, dtype=np.float64)
+    rpm = rpm_idle + (rpm_max - rpm_idle) * 0.5 * (
+        1.0 - np.cos(2.0 * np.pi * t_norm * n_cycles)
+    )
+
+    # Derive intervals from RPM (one interval per sample pair)
+    rps = rpm / 60.0
+    intervals_ns = (1e9 / (rps * SYNCHRO_EVENTS_PER_REV)).astype(np.int64)
+    intervals_ns = np.maximum(intervals_ns, 100_000)  # floor at 0.1 ms
+
+    # Build timestamps until we exceed the session duration
+    ts_list = [start_ns]
+    idx = 0
+    while ts_list[-1] + intervals_ns[idx] <= end_ns and idx < len(intervals_ns) - 1:
+        ts_list.append(ts_list[-1] + int(intervals_ns[idx]))
+        idx += 1
+
+    timestamps_ns = np.array(ts_list, dtype=np.int64)
+    n_samples = len(timestamps_ns)
+
+    # Angle-based signal value
+    angle = np.cumsum(
+        np.concatenate(
+            [[0.0], 360.0 / SYNCHRO_EVENTS_PER_REV * np.ones(n_samples - 1)]
+        )
+    )
+    samples = np.sin(np.radians(angle) + phase) * 50.0 + 50.0
+    return samples, timestamps_ns
+
+
+# ----------------------- helpers ---------------------------------
+def make_band_df(prefix: str, row_start: int, size: int) -> pd.DataFrame:
+    """Create a DataFrame for one rate band with the correct sample interval."""
+    meta = BAND_META[prefix]
+    idx = ORIGIN_T0 + pd.to_timedelta(
+        np.arange(row_start, row_start + size, dtype=np.int64) * meta["interval_ms"],
+        unit="ms",
+    )
+    base = (row_start + np.arange(size))[:, None] / 100.0
+    data = np.sin(base + meta["phases"])
+    return pd.DataFrame(data, index=idx, columns=meta["cols"])
+
+
+def open_connection(mode, identifier="", key=None, recorder=False):
+    """Return the appropriate session connection for the configured backend."""
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, session_key=key,
+            mode=mode, recorder=recorder,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, session_key=key,
+        mode=mode, recorder=recorder,
+    )
+
+
+class ValidationReport:
+    """Collects PASS / FAIL / SKIP results and prints a summary."""
+
+    def __init__(self):
+        self.results: list[tuple[str, str, str]] = []
+
+    def check(self, label: str, passed: bool, detail: str = ""):
+        status = "PASS" if passed else "FAIL"
+        self.results.append((status, label, detail))
+        symbol = "\u2713" if passed else "\u2717"
+        line = f"  {symbol} {label}"
+        if not passed and detail:
+            line += f"  ({detail})"
+        print(line)
+
+    def skip(self, label: str, reason: str = ""):
+        self.results.append(("SKIP", label, reason))
+        print(f"  \u2298 {label}  ({reason})")
+
+    @property
+    def passed(self):
+        return sum(1 for s, *_ in self.results if s == "PASS")
+
+    @property
+    def failed(self):
+        return sum(1 for s, *_ in self.results if s == "FAIL")
+
+    @property
+    def skipped(self):
+        return sum(1 for s, *_ in self.results if s == "SKIP")
+
+
+def check_param_attr(report, session, param_id, attr_name, expected, label, tol=None):
+    """Read a .NET Parameter property and compare to an expected value.
+
+    For resilience against .NET naming variations, accepts a pipe-separated
+    list of attribute names (e.g. ``"Units|Unit"``).  The first one found wins.
+    """
+    try:
+        param = session.GetParameter(param_id)
+    except Exception:
+        report.skip(label, f"parameter {param_id} not found")
+        return
+
+    candidates = [n.strip() for n in attr_name.split("|")]
+    actual = None
+    found = False
+    for name in candidates:
+        try:
+            actual = getattr(param, name)
+            found = True
+            break
+        except AttributeError:
+            continue
+
+    if not found:
+        report.skip(label, f"no attribute {candidates}")
+        return
+
+    if tol is not None:
+        ok = abs(float(actual) - float(expected)) < tol
+    else:
+        ok = str(actual) == str(expected)
+
+    detail = "" if ok else f"expected {expected!r}, got {actual!r}"
+    report.check(label, ok, detail)
+
+
+# ----------------------- main ------------------------------------
+def main():
+    session_id = (
+        f"Pandlas Validation - {pd.Timestamp.now().strftime('%y/%m/%d %H:%M:%S')}"
+    )
+
+    print(f"\n{'=' * 60}")
+    print("  Pandlas Performance & Validation Test")
+    print(f"{'=' * 60}")
+    print(f"  Backend:     {BACKEND}")
+    print(f"  Duration:    {SESSION_DURATION_S} s")
+    print(f"  Rate bands:")
+    for prefix, count, interval_ms in RATE_BANDS:
+        meta = BAND_META[prefix]
+        freq_hz = 1000 / interval_ms
+        print(f"    {prefix:>5}: {count:3d} params @ {freq_hz:,.0f} Hz "
+              f"({meta['n_rows']:,} rows)")
+    print(f"  Total params: {TOTAL_PARAMS}")
+    synchro_idle_hz = SYNCHRO_RPM_IDLE * SYNCHRO_EVENTS_PER_REV / 60
+    synchro_peak_hz = SYNCHRO_RPM_MAX * SYNCHRO_EVENTS_PER_REV / 60
+    print(f"  Synchro:     {len(SYNCHRO_SIGNALS)} params, "
+          f"{SYNCHRO_RPM_IDLE}-{SYNCHRO_RPM_MAX} RPM "
+          f"({synchro_idle_hz:.0f}-{synchro_peak_hz:.0f} Hz)")
+    print(f"  Origin:      {ORIGIN_T0}")
+    print(f"{'=' * 60}\n")
+
+    report = ValidationReport()
+
+    # ==================================================================
+    # Phase 1 — Write
+    # ==================================================================
+    print("Phase 1: Writing data with metadata ...\n")
+
+    # -- First batch of every band (establishes config) ----------------
+    first_frames = {}
+    for prefix, _, _ in RATE_BANDS:
+        meta = BAND_META[prefix]
+        df = make_band_df(prefix, 0, meta["batch_rows"])
+        df.atlas.ApplicationGroupName = "TestApp"
+        df.atlas.ParameterGroupIdentifier = f"Group_{prefix}"
+        first_frames[prefix] = df
+
+    # Apply rich metadata to the first band only
+    first_band_prefix = RATE_BANDS[0][0]
+    first_frames[first_band_prefix].atlas.units = CUSTOM_UNITS
+    first_frames[first_band_prefix].atlas.descriptions = CUSTOM_DESCRIPTIONS
+    first_frames[first_band_prefix].atlas.display_format = CUSTOM_FORMATS
+    first_frames[first_band_prefix].atlas.display_limits = CUSTOM_DISPLAY_LIMITS
+    first_frames[first_band_prefix].atlas.warning_limits = CUSTOM_WARNING_LIMITS
+
+    # -- Secondary group: full duration, different app group -----------
+    sec_meta = BAND_META[RATE_BANDS[2][0]]  # use medium-rate band for secondary
+    df_secondary = make_band_df(RATE_BANDS[2][0], 0, sec_meta["n_rows"])
+    sec_cols = [f"S{i:04d}" for i in range(sec_meta["count"])]
+    df_secondary.columns = sec_cols
+    df_secondary.atlas.ApplicationGroupName = "SecondaryApp"
+    df_secondary.atlas.ParameterGroupIdentifier = "SubGroup"
+    df_secondary.atlas.units = {f"{c}:SecondaryApp": "V" for c in sec_cols}
+
+    with open_connection("w", session_id) as session:
+        # --- config + first batch of each band (timed) ---
+        t0 = time.perf_counter()
+        for prefix, _, _ in RATE_BANDS:
+            first_frames[prefix].atlas.to_atlas_session(
+                session, show_progress_bar=False,
+            )
+        t1 = time.perf_counter()
+        cfg_time = t1 - t0
+
+        # secondary group
+        df_secondary.atlas.to_atlas_session(session, show_progress_bar=False)
+
+        # --- streaming remaining batches per band (timed) ---
+        total_samples = sum(
+            BAND_META[p]["batch_rows"] * BAND_META[p]["count"]
+            for p, _, _ in RATE_BANDS
+        )
+        t2 = time.perf_counter()
+        for prefix, _, _ in RATE_BANDS:
+            meta = BAND_META[prefix]
+            for row_start in range(meta["batch_rows"], meta["n_rows"],
+                                   meta["batch_rows"]):
+                bs = min(meta["batch_rows"], meta["n_rows"] - row_start)
+                df = make_band_df(prefix, row_start, bs)
+                df.atlas.ApplicationGroupName = "TestApp"
+                df.atlas.ParameterGroupIdentifier = f"Group_{prefix}"
+                df.atlas.to_atlas_session(session, show_progress_bar=False)
+                total_samples += bs * meta["count"]
+        t3 = time.perf_counter()
+        stream_time = max(1e-9, t3 - t2)
+
+        # laps and markers (after all data so timestamps are in range)
+        dur_ms = SESSION_DURATION_S * 1000
+
+        # --- Laps (individual calls) ---
+        sr.add_lap(session, ORIGIN_T0 + pd.Timedelta(dur_ms * 0.25, "ms"),
+                   2, "Formation Lap")
+        sr.add_lap(session, ORIGIN_T0 + pd.Timedelta(dur_ms * 0.50, "ms"),
+                   3, "Flying Lap", True)
+        sr.add_lap(session, ORIGIN_T0 + pd.Timedelta(dur_ms * 0.75, "ms"),
+                   4, "Cool Down Lap", False)
+
+        # --- Update lap (rename the auto-created first lap) ---
+        sr.update_lap(session, lap_index=0, new_name="Out Lap")
+
+        # --- Individual markers ---
+        sr.add_point_marker(
+            session, ORIGIN_T0 + pd.Timedelta(100, "ms"),
+            "Pit Entry",
+        )
+        sr.add_range_marker(
+            session,
+            ORIGIN_T0 + pd.Timedelta(200, "ms"),
+            ORIGIN_T0 + pd.Timedelta(500, "ms"),
+            "Safety Car",
+            marker_description="Yellow flag period",
+        )
+
+        # --- Batch markers (single .Add call) ---
+        sr.add_markers_batch(session, [
+            {"time": ORIGIN_T0 + pd.Timedelta(dur_ms * 0.10, "ms"),
+             "label": "DRS Enabled"},
+            {"time": ORIGIN_T0 + pd.Timedelta(dur_ms * 0.60, "ms"),
+             "label": "Fastest Sector"},
+            {"start_time": ORIGIN_T0 + pd.Timedelta(dur_ms * 0.30, "ms"),
+             "end_time":   ORIGIN_T0 + pd.Timedelta(dur_ms * 0.40, "ms"),
+             "label": "Harvest Zone",
+             "group": "ENERGY",
+             "description": "Low SOC harvesting phase"},
+            {"start_time": ORIGIN_T0 + pd.Timedelta(dur_ms * 0.55, "ms"),
+             "end_time":   ORIGIN_T0 + pd.Timedelta(dur_ms * 0.65, "ms"),
+             "label": "Deploy Zone",
+             "group": "ENERGY",
+             "description": "High power deploy phase"},
+        ])
+
+        # --- Synchro (engine-synchronous) signals ---
+        print("  Writing synchro signals ...")
+        synchro_t0 = time.perf_counter()
+        # Align synchro timestamps to the session origin
+        origin_ns = int(timestamp2long(ORIGIN_T0))
+        synchro_total = 0
+        for i, (name, unit, desc) in enumerate(SYNCHRO_SIGNALS):
+            samples, ts_ns = generate_synchro_signal(
+                start_ns=origin_ns,
+                duration_s=SESSION_DURATION_S,
+                phase=i * 0.5,
+            )
+            synchro_total += len(samples)
+            add_synchro_data(
+                session,
+                parameter_name=name,
+                app_group="SynchroApp",
+                samples=samples,
+                timestamps=ts_ns,
+                unit=unit,
+                description=desc,
+            )
+        synchro_time = time.perf_counter() - synchro_t0
+        print(f"  Synchro time:  {synchro_time:.3f} s  "
+              f"({synchro_total:,} samples, "
+              f"{synchro_total / synchro_time:,.0f} samples/s)")
+
+        session_key = session.Key.ToString()
+
+    total_time = cfg_time + stream_time
+    print(f"  Config time:   {cfg_time:.3f} s")
+    print(f"  Stream time:   {stream_time:.3f} s")
+    print(f"  Total samples: {total_samples:,}")
+    print(f"  Stream rate:   {total_samples / stream_time:,.0f} samples/s")
+    print(f"  Overall rate:  {total_samples / total_time:,.0f} samples/s")
+
+    # ==================================================================
+    # Phase 2 — Read back and validate
+    # ==================================================================
+    print(f"\nPhase 2: Validating metadata ...\n")
+
+    with open_connection("r", key=session_key) as session:
+
+        # --- 2a. Custom units ---
+        for pid, expected_unit in CUSTOM_UNITS.items():
+            check_param_attr(
+                report, session, pid, "Units|Unit", expected_unit,
+                f"unit  {pid}",
+            )
+
+        # --- 2b. Custom descriptions ---
+        for pid, expected_desc in CUSTOM_DESCRIPTIONS.items():
+            check_param_attr(
+                report, session, pid, "Description", expected_desc,
+                f"desc  {pid}",
+            )
+
+        # --- 2c. Custom display format ---
+        for pid, expected_fmt in CUSTOM_FORMATS.items():
+            check_param_attr(
+                report, session, pid, "FormatOverride", expected_fmt,
+                f"fmt   {pid}",
+            )
+
+        # --- 2d. Custom display limits ---
+        for pid, (lo, hi) in CUSTOM_DISPLAY_LIMITS.items():
+            check_param_attr(
+                report, session, pid, "MinimumValue", lo,
+                f"dLo   {pid}", tol=1e-6,
+            )
+            check_param_attr(
+                report, session, pid, "MaximumValue", hi,
+                f"dHi   {pid}", tol=1e-6,
+            )
+
+        # --- 2e. Custom warning limits ---
+        for pid, (lo, hi) in CUSTOM_WARNING_LIMITS.items():
+            check_param_attr(
+                report, session, pid, "WarningMinimumValue", lo,
+                f"wLo   {pid}", tol=1e-6,
+            )
+            check_param_attr(
+                report, session, pid, "WarningMaximumValue", hi,
+                f"wHi   {pid}", tol=1e-6,
+            )
+
+        # --- 2f. Default limits (auto-computed from data) ---
+        # A parameter without custom limits should use its data min/max.
+        auto_col = BAND_META[first_band_prefix]["cols"][5]  # 6th param, no custom limits
+        pid_auto = f"{auto_col}:TestApp"
+        try:
+            auto_data = (
+                first_frames[first_band_prefix][auto_col]
+                .dropna().to_numpy().astype(np.float32)
+            )
+            check_param_attr(
+                report, session, pid_auto, "MinimumValue",
+                float(auto_data.min()), f"auto dLo {pid_auto}", tol=1e-4,
+            )
+            check_param_attr(
+                report, session, pid_auto, "MaximumValue",
+                float(auto_data.max()), f"auto dHi {pid_auto}", tol=1e-4,
+            )
+        except Exception as exc:
+            report.skip(f"auto limits {pid_auto}", str(exc))
+
+        # --- 2g. Secondary app group exists ---
+        has_secondary = session.ContainsParameter("S0000:SecondaryApp")
+        report.check("multi-group  S0000:SecondaryApp exists", has_secondary)
+
+        for c in sec_cols[:5]:
+            pid_sec = f"{c}:SecondaryApp"
+            check_param_attr(
+                report, session, pid_sec, "Units|Unit", "V",
+                f"unit  {pid_sec}",
+            )
+
+        # --- 2h. Laps ---
+        lap_count = session.LapCollection.Count
+        report.check(f"laps  count >= 4 (got {lap_count})", lap_count >= 4)
+
+        # Check a specific lap name
+        lap_names = [session.LapCollection[i].Name for i in range(lap_count)]
+        report.check(
+            'lap   "Flying Lap" present',
+            "Flying Lap" in lap_names,
+        )
+        report.check(
+            'lap   "Cool Down Lap" present',
+            "Cool Down Lap" in lap_names,
+        )
+        # Validate update_lap renamed Lap 1 → "Out Lap"
+        report.check(
+            'lap   "Out Lap" (renamed) present',
+            "Out Lap" in lap_names,
+        )
+
+        # --- 2i. Markers ---
+        marker_count = session.Markers.Count
+        report.check(f"markers  count >= 6 (got {marker_count})", marker_count >= 6)
+
+        marker_labels = [session.Markers[i].Label for i in range(marker_count)]
+        for expected_label in [
+            "Pit Entry", "Safety Car", "DRS Enabled",
+            "Fastest Sector", "Harvest Zone", "Deploy Zone",
+        ]:
+            report.check(
+                f'marker "{expected_label}" present',
+                expected_label in marker_labels,
+            )
+
+        # --- 2j. Synchro parameters exist with correct metadata ---
+        for name, unit, desc in SYNCHRO_SIGNALS:
+            pid = f"{name}:SynchroApp"
+            has_sync = session.ContainsParameter(pid)
+            report.check(f"synchro  {pid} exists", has_sync)
+            if has_sync:
+                check_param_attr(
+                    report, session, pid, "Units|Unit", unit,
+                    f"synchro unit  {pid}",
+                )
+                check_param_attr(
+                    report, session, pid, "Description", desc,
+                    f"synchro desc  {pid}",
+                )
+
+        # ==============================================================
+        # Phase 3 — Data integrity (one parameter per rate band)
+        # ==============================================================
+        print(f"\nPhase 3: Validating data integrity ...\n")
+
+        for prefix, _, _ in RATE_BANDS:
+            meta = BAND_META[prefix]
+            first_col = meta["cols"][0]
+            pid = f"{first_col}:TestApp"
+            samples, timestamps = sr.get_samples(session, pid)
+            expected_data = np.sin(
+                np.arange(meta["n_rows"]) / 100.0 + meta["phases"][0]
+            ).astype(np.float32)
+
+            freq_hz = 1000 / meta["interval_ms"]
+            report.check(
+                f"count {first_col} @{freq_hz:.0f}Hz "
+                f"({len(samples)}/{meta['n_rows']})",
+                len(samples) == meta["n_rows"],
+            )
+
+            if len(samples) == meta["n_rows"]:
+                data_ok = np.allclose(
+                    samples.astype(np.float32), expected_data, atol=1e-6,
+                )
+                report.check(
+                    f"data  {first_col} @{freq_hz:.0f}Hz round-trip", data_ok,
+                )
+            else:
+                report.skip(
+                    f"data  {first_col} @{freq_hz:.0f}Hz",
+                    "sample count mismatch",
+                )
+
+    # ==================================================================
+    # Summary
+    # ==================================================================
+    print(f"\n{'=' * 60}")
+    print("  RESULTS SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"  Parameters:     {TOTAL_PARAMS} across {len(RATE_BANDS)} rate bands")
+    print(f"  Session:        {SESSION_DURATION_S} s")
+    total_rows_all = sum(BAND_META[p]["n_rows"] for p, _, _ in RATE_BANDS)
+    print(f"  Rows written:   {total_rows_all:,} (all bands)")
+    print(f"  Total samples:  {total_samples:,}")
+    print(f"  Config time:    {cfg_time:.3f} s")
+    print(f"  Stream time:    {stream_time:.3f} s")
+    print(f"  Synchro time:   {synchro_time:.3f} s  ({synchro_total:,} samples)")
+    print(f"  Total time:     {total_time + synchro_time:.3f} s")
+    print(f"  Row throughput: {total_samples / total_time:,.0f} samples/s")
+    print(f"  Sync throughput:{synchro_total / synchro_time:,.0f} samples/s")
+    print(f"  Validation:     {report.passed} passed, "
+          f"{report.failed} failed, {report.skipped} skipped")
+    print(f"{'=' * 60}\n")
+
+    if report.failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/example/session_features.py
+++ b/example/session_features.py
@@ -1,0 +1,315 @@
+"""
+Pandlas Features Test
+=====================
+
+Validates three features:
+  1. Session Details — writing session-level metadata (Driver, Circuit, etc.)
+  2. Parameter Grouping — auto-creating parameter groups from column separators
+  3. Text Channels — writing enumerated text parameters with TextConversion
+
+Requirements:
+  - ATLAS 10 installed with SQL Race API available
+  - pandlas installed
+
+Usage:
+    python features_test.py
+"""
+
+import sys
+import time
+import logging
+import numpy as np
+import pandas as pd
+
+from pandlas import SQLiteConnection, SQLRaceDBConnection
+from pandlas import add_text_channel
+from pandlas.utils import timestamp2long
+import pandlas.SqlRace as sr
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ========================= CONFIGURATION =========================
+BACKEND = "sqlserver"
+
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\FeaturesTest.ssndb"
+
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+SESSION_DURATION_S = 10
+SAMPLE_RATE_MS = 100  # 10 Hz
+TOTAL_ROWS = int(SESSION_DURATION_S * 1000 / SAMPLE_RATE_MS)
+
+ORIGIN_T0 = pd.Timestamp.now()
+
+# Session details to write and validate
+SESSION_DETAILS = {
+    "Driver": "Lando Norris",
+    "Circuit": "Silverstone",
+    "Vehicle": "MCL60",
+    "Event": "British GP 2026",
+    "Session": "FP1",
+    "Comment": "Pandlas features validation test",
+}
+
+# Parameter grouping config — columns use "/" separator
+GROUPED_COLUMNS = {
+    "Chassis/DamperFL": "mm",
+    "Chassis/DamperFR": "mm",
+    "Chassis/DamperRL": "mm",
+    "Chassis/DamperRR": "mm",
+    "Engine/RPM": "rpm",
+    "Engine/OilTemp": "degC",
+    "Engine/WaterTemp": "degC",
+    "Strategy/FuelRemaining": "kg",
+    "Strategy/TyreDeg": "%",
+}
+
+# Text channel config
+TEXT_GEARS = ["N", "1", "2", "3", "4", "5", "6", "7", "8"]
+TEXT_DRS = ["Closed", "Open"]
+TEXT_MODE = ["Qualify", "Race", "Deploy", "Harvest", "Safety Car"]
+# =================================================================
+
+
+class ValidationReport:
+    """Simple pass/fail/skip test report."""
+
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+
+    def check(self, label: str, condition: bool):
+        if condition:
+            self.passed += 1
+            print(f"  \u2713 {label}")
+        else:
+            self.failed += 1
+            print(f"  \u2717 {label}")
+
+    def skip(self, label: str, reason: str = ""):
+        self.skipped += 1
+        print(f"  \u2298 {label}  ({reason})")
+
+
+def check_param_attr(report, session, param_id, attr_names, expected, label,
+                     tol=None):
+    """Check a parameter attribute, trying pipe-separated fallback names."""
+    try:
+        param = session.GetParameter(param_id)
+        for attr_name in attr_names.split("|"):
+            if hasattr(param, attr_name):
+                actual = getattr(param, attr_name)
+                if tol is not None:
+                    ok = abs(float(actual) - float(expected)) <= tol
+                else:
+                    ok = str(actual) == str(expected)
+                report.check(f"{label}  ('{actual}' == '{expected}')", ok)
+                return
+        report.skip(label, f"no attribute '{attr_names}'")
+    except Exception as exc:
+        report.skip(label, str(exc))
+
+
+def open_connection(mode, identifier="", key=None):
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, session_key=key, mode=mode,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, session_key=key, mode=mode,
+    )
+
+
+def main():
+    print(f"\n{'=' * 60}")
+    print("  Pandlas Features Test")
+    print(f"{'=' * 60}")
+    print(f"  Backend:     {BACKEND}")
+    print(f"  Duration:    {SESSION_DURATION_S} s ({TOTAL_ROWS} rows @ "
+          f"{1000 / SAMPLE_RATE_MS:.0f} Hz)")
+    print(f"  Grouped:     {len(GROUPED_COLUMNS)} params in "
+          f"{len(set(c.split('/')[0] for c in GROUPED_COLUMNS))} groups")
+    print(f"  Text params: 3 (Gear, DRS, Mode)")
+    print(f"  Details:     {len(SESSION_DETAILS)} keys")
+    print(f"  Origin:      {ORIGIN_T0}")
+    print(f"{'=' * 60}\n")
+
+    report = ValidationReport()
+
+    session_id = (
+        f"Features Test - {pd.Timestamp.now():%y/%m/%d %H:%M:%S}"
+    )
+
+    # ==================================================================
+    # Phase 1 — Write
+    # ==================================================================
+    print("Phase 1: Writing data ...\n")
+
+    with open_connection("w", session_id) as session:
+        t0 = time.perf_counter()
+
+        # --- 1a. Session details ---
+        sr.set_session_details(session, SESSION_DETAILS)
+        print("  Session details set.")
+
+        # --- 1b. Grouped parameters ---
+        idx = pd.date_range(ORIGIN_T0, periods=TOTAL_ROWS,
+                            freq=f"{SAMPLE_RATE_MS}ms")
+        t = np.arange(TOTAL_ROWS, dtype=np.float64)
+
+        grouped_data = {}
+        for i, col in enumerate(GROUPED_COLUMNS):
+            grouped_data[col] = np.sin(t / 10.0 + i) * 50.0 + 50.0
+
+        df_grouped = pd.DataFrame(grouped_data, index=idx)
+        df_grouped.atlas.ApplicationGroupName = "CarData"
+        df_grouped.atlas.parameter_group_separator = "/"
+
+        # Set units using the clean param identifier
+        for col, unit in GROUPED_COLUMNS.items():
+            clean = col.split("/")[1]
+            df_grouped.atlas.units[f"{clean}:CarData"] = unit
+
+        df_grouped.atlas.to_atlas_session(session, show_progress_bar=False)
+        print(f"  Grouped data written ({len(GROUPED_COLUMNS)} params).")
+
+        # --- 1c. Text channels ---
+        # Gear: cycles through gear sequence
+        gear_indices = np.tile(
+            np.arange(len(TEXT_GEARS)),
+            TOTAL_ROWS // len(TEXT_GEARS) + 1,
+        )[:TOTAL_ROWS]
+        gear_values = [TEXT_GEARS[i] for i in gear_indices]
+
+        add_text_channel(
+            session,
+            parameter_name="Gear",
+            values=gear_values,
+            timestamps=idx,
+            application_group="DriverInputs",
+            description="Current gear selection",
+        )
+        print("  Text channel 'Gear' written.")
+
+        # DRS: alternates open/closed
+        drs_values = [TEXT_DRS[i % 2] for i in range(TOTAL_ROWS)]
+        add_text_channel(
+            session,
+            parameter_name="DRS",
+            values=drs_values,
+            timestamps=idx,
+            application_group="DriverInputs",
+            description="DRS flap state",
+        )
+        print("  Text channel 'DRS' written.")
+
+        # Mode: cycles through strategy modes
+        mode_values = [TEXT_MODE[i % len(TEXT_MODE)] for i in range(TOTAL_ROWS)]
+        add_text_channel(
+            session,
+            parameter_name="Mode",
+            values=mode_values,
+            timestamps=idx,
+            application_group="Strategy",
+            description="Power unit operating mode",
+        )
+        print("  Text channel 'Mode' written.")
+
+        write_time = time.perf_counter() - t0
+        session_key = session.Key.ToString()
+
+    print(f"\n  Total write time: {write_time:.3f} s")
+
+    # ==================================================================
+    # Phase 2 — Validate
+    # ==================================================================
+    print(f"\nPhase 2: Validating ...\n")
+
+    with open_connection("r", key=session_key) as session:
+
+        # --- 2a. Session details ---
+        print("  --- Session Details ---")
+        items = session.Items
+        item_dict = {}
+        for i in range(items.Count):
+            it = items[i]
+            try:
+                item_dict[it.Name] = it.Value
+            except Exception:
+                pass
+
+        for key, expected in SESSION_DETAILS.items():
+            actual = item_dict.get(key, None)
+            if actual is not None:
+                report.check(
+                    f'detail  "{key}" = "{actual}"',
+                    str(actual) == str(expected),
+                )
+            else:
+                report.skip(f'detail  "{key}"', "not found in Items")
+
+        # --- 2b. Parameter grouping ---
+        print("\n  --- Parameter Grouping ---")
+        for col in GROUPED_COLUMNS:
+            clean = col.split("/")[1]
+            pid = f"{clean}:CarData"
+            exists = session.ContainsParameter(pid)
+            report.check(f"grouped  {pid} exists", exists)
+
+        # Check units on grouped params
+        for col, expected_unit in GROUPED_COLUMNS.items():
+            clean = col.split("/")[1]
+            pid = f"{clean}:CarData"
+            if session.ContainsParameter(pid):
+                check_param_attr(
+                    report, session, pid, "Units|Unit", expected_unit,
+                    f"unit     {pid}",
+                )
+
+        # --- 2c. Text channels ---
+        print("\n  --- Text Channels ---")
+        text_checks = [
+            ("Gear", "DriverInputs", TEXT_GEARS, "Current gear selection"),
+            ("DRS", "DriverInputs", TEXT_DRS, "DRS flap state"),
+            ("Mode", "Strategy", TEXT_MODE, "Power unit operating mode"),
+        ]
+        for name, app, labels, expected_desc in text_checks:
+            pid = f"{name}:{app}"
+            exists = session.ContainsParameter(pid)
+            report.check(f"text  {pid} exists", exists)
+
+            if exists:
+                check_param_attr(
+                    report, session, pid, "Description", expected_desc,
+                    f"desc  {pid}",
+                )
+                # Read back data and verify round-trip
+                try:
+                    samples, timestamps = sr.get_samples(session, pid)
+                    report.check(
+                        f"text  {pid} count ({len(samples)}/{TOTAL_ROWS})",
+                        len(samples) == TOTAL_ROWS,
+                    )
+                except Exception as exc:
+                    report.skip(f"text  {pid} read-back", str(exc))
+
+    # ==================================================================
+    # Summary
+    # ==================================================================
+    print(f"\n{'=' * 60}")
+    print("  RESULTS SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"  Write time:    {write_time:.3f} s")
+    print(f"  Validation:    {report.passed} passed, "
+          f"{report.failed} failed, {report.skipped} skipped")
+    print(f"{'=' * 60}\n")
+
+    if report.failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/example/synchro_benchmark.py
+++ b/example/synchro_benchmark.py
@@ -1,0 +1,246 @@
+"""
+Pandlas Synchro Performance Test
+================================
+
+Benchmarks writing variable-rate (synchro) data to an ATLAS session at
+different scales.  All test points are written into a **single session**
+so they can be viewed together in ATLAS.
+
+The data simulates engine-crank-synchronous signals where the sample
+interval is driven by RPM.  RPM sweeps from idle (800 RPM) up to a
+configurable max (default 21 000 RPM), producing sample intervals that
+range from ~2.3 ms at idle down to ~0.079 ms at peak RPM — matching
+real powertrain telemetry with a 36-tooth crank trigger wheel.
+
+Default test points: 100K, 1M, 10M samples.
+Adjust SAMPLE_COUNTS to test larger scales (100M+).
+
+Requirements:
+  - ATLAS 10 installed with SQL Race API available
+  - pandlas installed
+
+Usage:
+    python synchro_performance_test.py
+"""
+
+import sys
+import time
+import logging
+
+import numpy as np
+import pandas as pd
+
+from pandlas import SQLiteConnection, SQLRaceDBConnection
+from pandlas import add_synchro_data
+import pandlas.SqlRace as sr
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ========================= CONFIGURATION =========================
+# Backend: "sqlite" or "sqlserver"
+BACKEND = "sqlserver"
+
+# SQLite settings
+SQLITE_DB_DIR = r"C:\McLaren Applied\pandlas\SynchroTest.ssndb"
+
+# SQL Server settings (only used when BACKEND = "sqlserver")
+SERVER = r"MCLA-525Q374\LOCAL"
+DATABASE = "SQLRACE02"
+
+# Test points — all written into one session, each as a separate parameter
+SAMPLE_COUNTS = [100_000, 1_000_000, 10_000_000]
+
+# Engine RPM profile
+RPM_IDLE = 800          # idle RPM
+RPM_MAX = 21_000        # peak RPM
+RPM_CYCLES = 5          # number of idle-max-idle sweeps in the session
+TEETH_PER_REV = 36      # crank trigger teeth per revolution (typ. 36-1 or 60-2)
+PACKET_SIZE = 8_000     # samples per synchro packet
+# =================================================================
+
+
+def rpm_to_interval_ns(rpm: np.ndarray, teeth_per_rev: int = TEETH_PER_REV) -> np.ndarray:
+    """Convert RPM profile to inter-sample intervals in nanoseconds.
+
+    At a given RPM, the time between crank teeth is::
+
+        interval = 60 / (RPM * teeth_per_rev)  [seconds]
+
+    800 RPM / 36 teeth  ->  ~2.31 ms  (433 Hz)
+    21 000 RPM / 36 teeth  ->  ~0.079 ms  (12 600 Hz)
+    """
+    rps = rpm / 60.0
+    interval_s = 1.0 / (rps * teeth_per_rev)
+    return (interval_s * 1e9).astype(np.int64)
+
+
+def generate_engine_synchro_data(
+    n_samples: int,
+    rpm_idle: float = RPM_IDLE,
+    rpm_max: float = RPM_MAX,
+    n_cycles: int = RPM_CYCLES,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate synchro data with a realistic engine RPM sweep.
+
+    RPM sweeps sinusoidally between ``rpm_idle`` and ``rpm_max`` over
+    ``n_cycles`` full oscillations, producing sample intervals that range
+    from ~2.3 ms (idle) to ~0.079 ms (peak RPM).
+
+    Returns:
+        (samples, timestamps_ns) — both 1-D arrays.
+    """
+    # RPM profile: cosine sweep idle -> max -> idle
+    t = np.arange(n_samples, dtype=np.float64)
+    rpm_profile = (
+        rpm_idle + (rpm_max - rpm_idle)
+        * 0.5 * (1.0 - np.cos(2.0 * np.pi * t / max(n_samples, 1) * n_cycles))
+    )
+
+    # Inter-sample intervals from RPM (N-1 intervals for N samples)
+    intervals_ns = rpm_to_interval_ns(rpm_profile[:-1])
+    intervals_ns = np.maximum(intervals_ns, 1000)  # floor at 1 us
+
+    # Timestamps (ns from midnight, starting at 1 h)
+    timestamps_ns = np.empty(n_samples, dtype=np.int64)
+    timestamps_ns[0] = 3_600_000_000_000  # 1 hour
+    timestamps_ns[1:] = timestamps_ns[0] + np.cumsum(intervals_ns)
+
+    # Signal: crank-angle-synchronous combustion pressure (sinusoidal approx)
+    angle = np.cumsum(
+        np.concatenate([[0.0], 360.0 / TEETH_PER_REV * np.ones(n_samples - 1)])
+    )
+    samples = np.sin(np.radians(angle)) * 50.0 + 50.0  # 0-100 bar range
+
+    return samples, timestamps_ns
+
+
+def open_connection(mode, identifier="", key=None):
+    """Return the appropriate session connection for the configured backend."""
+    if BACKEND == "sqlite":
+        return SQLiteConnection(
+            SQLITE_DB_DIR, identifier, session_key=key, mode=mode,
+        )
+    return SQLRaceDBConnection(
+        SERVER, DATABASE, identifier, session_key=key, mode=mode,
+    )
+
+
+def main():
+    freq_idle = RPM_IDLE / 60 * TEETH_PER_REV
+    freq_max = RPM_MAX / 60 * TEETH_PER_REV
+    int_idle_ms = 1e9 / freq_idle / 1e6
+    int_max_ms = 1e9 / freq_max / 1e6
+
+    print(f"\n{'=' * 65}")
+    print("  Pandlas Synchro Performance Test")
+    print(f"{'=' * 65}")
+    print(f"  Backend:       {BACKEND}")
+    print(f"  RPM range:     {RPM_IDLE:,} - {RPM_MAX:,} RPM  ({RPM_CYCLES} sweeps)")
+    print(f"  Crank teeth:   {TEETH_PER_REV} per rev")
+    print(f"  Sample rate:   {freq_idle:,.0f} Hz (idle) - {freq_max:,.0f} Hz (peak)")
+    print(f"  Interval:      {int_idle_ms:.3f} ms (idle) - {int_max_ms:.4f} ms (peak)")
+    print(f"  Packet size:   {PACKET_SIZE:,}")
+    print(f"  Test points:   {[f'{n:,}' for n in SAMPLE_COUNTS]}")
+    print(f"  All signals written to a single session")
+    print(f"{'=' * 65}\n")
+
+    results = []
+
+    session_id = (
+        f"Synchro Perf - {pd.Timestamp.now():%y/%m/%d %H:%M:%S}"
+    )
+
+    with open_connection("w", session_id) as session:
+        for i, n_samples in enumerate(SAMPLE_COUNTS):
+            param_name = f"Synchro_{n_samples // 1000}K"
+
+            print(f"\n{'~' * 55}")
+            print(f"  {param_name}  ({n_samples:,} samples)")
+            print(f"{'~' * 55}")
+
+            # ---- Generate ----
+            t0 = time.perf_counter()
+            samples, timestamps_ns = generate_engine_synchro_data(n_samples)
+            t_gen = time.perf_counter() - t0
+
+            duration_s = (timestamps_ns[-1] - timestamps_ns[0]) / 1e9
+            print(f"  Data gen:     {t_gen:.3f} s  "
+                  f"(simulated duration {duration_s:.2f} s)")
+
+            # ---- Write ----
+            t1 = time.perf_counter()
+            add_synchro_data(
+                session,
+                samples,
+                timestamps_ns,
+                parameter_name=param_name,
+                app_group="EngineSync",
+                param_group="CrankSync",
+                unit="bar",
+                description=(
+                    f"Crank-sync combustion pressure, {n_samples:,} samples, "
+                    f"{RPM_IDLE}-{RPM_MAX} RPM"
+                ),
+                packet_size=PACKET_SIZE,
+                show_progress_bar=True,
+            )
+            t_write = time.perf_counter() - t1
+
+            rate = n_samples / max(t_write, 1e-9)
+            print(f"  Write time:   {t_write:.3f} s")
+            print(f"  Throughput:   {rate:,.0f} samples/s")
+            print(f"  Data rate:    {rate * 8 / 1e6:,.1f} MB/s")
+
+            results.append({
+                "param": param_name,
+                "n_samples": n_samples,
+                "t_gen": t_gen,
+                "t_write": t_write,
+                "rate": rate,
+                "duration_s": duration_s,
+            })
+
+        session_key = session.Key.ToString()
+
+    # ---- Validate smallest parameter ----
+    smallest = SAMPLE_COUNTS[0]
+    smallest_param = f"Synchro_{smallest // 1000}K"
+    print(f"\nValidating {smallest_param} ({smallest:,} samples) ...")
+
+    with open_connection("r", key=session_key) as session:
+        read_samples, read_ts = sr.get_samples(
+            session, f"{smallest_param}:EngineSync",
+        )
+        ref_samples, _ = generate_engine_synchro_data(smallest)
+        count_ok = len(read_samples) == smallest
+        data_ok = (
+            np.allclose(read_samples.astype(np.float64), ref_samples, atol=1e-10)
+            if count_ok else False
+        )
+        if count_ok and data_ok:
+            print(f"  \u2713 Data integrity OK "
+                  f"({len(read_samples):,} / {smallest:,})")
+        else:
+            print(f"  \u2717 Data integrity FAILED "
+                  f"(count {len(read_samples):,}/{smallest:,}, "
+                  f"values_ok={data_ok})")
+
+    # ---- Summary ----
+    print(f"\n{'=' * 65}")
+    print("  RESULTS SUMMARY")
+    print(f"{'=' * 65}")
+    print(f"  {'Parameter':<20}  {'Samples':>12}  {'Sim (s)':>8}  "
+          f"{'Write (s)':>10}  {'Rate':>14}")
+    print(f"  {'-' * 20}  {'-' * 12}  {'-' * 8}  {'-' * 10}  {'-' * 14}")
+    for r in results:
+        print(
+            f"  {r['param']:<20}  {r['n_samples']:>12,}  "
+            f"{r['duration_s']:>8.2f}  "
+            f"{r['t_write']:>10.3f}  {r['rate']:>12,.0f} /s"
+        )
+    print(f"{'=' * 65}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/pandlas/SqlRace.py
+++ b/pandlas/SqlRace.py
@@ -1,10 +1,15 @@
 """Pythonized version of common SQLRace calls"""
 
 import os
+import math
+import random
+import functools
 from abc import ABC, abstractmethod
+from typing import Union
 import logging
 import pandas as pd
 import numpy as np
+from tqdm import tqdm
 from pandlas.utils import is_port_in_use, timestamp2long
 
 A10_INSTALL_PATH = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10"
@@ -51,6 +56,16 @@ from MESL.SqlRace.Domain import (
     Session,
     Lap,
     Marker,
+    ConfigurationSetManager,
+    ParameterGroup,
+    ApplicationGroup,
+    RationalConversion,
+    TextConversion,
+    EventDefinition,
+    ConfigurationSetAlreadyExistsException,
+    ConfigurationSet,
+    Parameter,
+    Channel,
 )
 
 # .NET imports, so pylint: disable=wrong-import-position,wrong-import-order,import-error,wildcard-import
@@ -58,12 +73,17 @@ from System import (
     DateTime,
     Guid,
     Byte,
+    Double,
+    String,
+    UInt32,
     Array,
+    Int64,
 )
 
 # .NET imports, so pylint: disable=wrong-import-position,wrong-import-order,import-error,wildcard-import
 from System.Collections.Generic import (
     List,
+    List as NETList,
 )
 
 # .NET imports, so pylint: disable=wrong-import-position,wrong-import-order,import-error,wildcard-import
@@ -71,6 +91,9 @@ from System.Net import (
     IPEndPoint,
     IPAddress,
 )
+
+# .NET imports, so pylint: disable=wrong-import-position,wrong-import-order,import-error,wildcard-import
+from MESL.SqlRace.Enumerators import DataType, ChannelDataSourceType, EventPriorityType, DeleteSessionOption
 
 
 def initialise_sqlrace():
@@ -204,7 +227,7 @@ class SQLiteConnection(SessionConnection):
             self.db_location,
             self.db_location,
             self.connection_string,
-            False,
+            DeleteSessionOption.NoSessionDelete,
         )
         if self.sessionManager.ServerListener.IsRunning:
             logger.info(
@@ -256,7 +279,7 @@ class Ssn2Session(SessionConnection):
 
     def load_session(self):
         """Loads the session from the SSN2 file."""
-        connection_string = f"DbEngine=SQLite;Data Source= {self.db_location}"
+        connection_string = f"DbEngine=SQLite;Data Source={self.db_location}"
         # .NET objects, so pylint: disable=invalid-name
         stateList = List[SessionState]()
         stateList.Add(SessionState.Historical)
@@ -388,7 +411,7 @@ class SQLRaceDBConnection(SessionConnection):
             rf"{self.data_source}\{self.database}",
             rf"{self.data_source}\{self.database}",
             self.connection_string,
-            False,
+            DeleteSessionOption.NoSessionDelete,
         )
         if self.sessionManager.ServerListener.IsRunning:
             logger.info(
@@ -504,25 +527,71 @@ def add_lap(
     logger.info('Lap "%s" with number %i added at %s', lap_name, lap_number, timestamp)
 
 
-def add_point_marker(
-    session: Session, marker_time: pd.Timestamp, marker_label: str
+def update_lap(
+    session: Session,
+    lap_index: int,
+    new_name: str = None,
+    new_count_for_fastest: bool = None,
 ) -> None:
-    """Adds a point marker to the session
+    """Update an existing lap in the session.
+
+    Retrieves the lap at ``lap_index``, modifies the requested fields,
+    and calls ``session.LapCollection.Update(lap)`` to persist the change.
+
+    Args:
+        session: MESL.SqlRace.Domain.Session containing the lap.
+        lap_index: Zero-based index in ``session.LapCollection``.
+        new_name: New name for the lap.  ``None`` keeps the current name.
+        new_count_for_fastest: New value for the CountForFastestLap flag.
+            ``None`` keeps the current value.
+
+    Raises:
+        IndexError: If ``lap_index`` is out of range.
+    """
+    lap_count = session.LapCollection.Count
+    if lap_index < 0 or lap_index >= lap_count:
+        raise IndexError(
+            f"lap_index {lap_index} out of range (0..{lap_count - 1})"
+        )
+
+    lap = session.LapCollection[lap_index]
+    old_name = lap.Name
+
+    if new_name is not None:
+        lap.Name = new_name
+    if new_count_for_fastest is not None:
+        lap.CountForFastestLap = new_count_for_fastest
+
+    session.LapCollection.Update(lap)
+    logger.info(
+        'Lap at index %d updated: "%s" -> "%s"',
+        lap_index,
+        old_name,
+        lap.Name,
+    )
+
+
+def add_point_marker(
+    session: Session,
+    marker_time: pd.Timestamp,
+    marker_label: str,
+) -> None:
+    """Adds a point marker to the session.
 
     Args:
         session: MESL.SqlRace.Domain.Session to add the point marker to.
-        marker_time: Time of the marker
-        marker_label: Label of the marker
-
-    Returns:
-        None
+        marker_time: Time of the marker.
+        marker_label: Label of the marker.
     """
     marker_time = timestamp2long(marker_time)
-    # .NET objects, so pylint: disable=invalid-name
-    newPointMarker = Marker(int(marker_time), marker_label)
-    # .NET objects, so pylint: disable=invalid-name
-    newMarkers = Array[Marker]([newPointMarker])
+    newPointMarker = Marker(  # .NET objects, so pylint: disable=invalid-name
+        int(marker_time), marker_label
+    )
+    newMarkers = Array[Marker](  # .NET objects, so pylint: disable=invalid-name
+        [newPointMarker]
+    )
     session.Markers.Add(newMarkers)
+    logger.info('Point marker "%s" added.', marker_label)
 
 
 def add_range_marker(
@@ -530,24 +599,778 @@ def add_range_marker(
     marker_start_time: pd.Timestamp,
     marker_end_time: pd.Timestamp,
     marker_label: str,
+    marker_group: str = "MARKER",
+    marker_description: str = "",
 ) -> None:
     """Adds a range marker to the session.
 
     Args:
         session: MESL.SqlRace.Domain.Session to add the range marker to.
-        marker_start_time: Start time of the range marker
-        marker_end_time: End time of the range marker
-        marker_label: Label of the marker
-
-    Returns:
-        None
+        marker_start_time: Start time of the range marker.
+        marker_end_time: End time of the range marker.
+        marker_label: Label of the marker.
+        marker_group: Group name for the marker. Default ``"MARKER"``.
+        marker_description: Description text for the marker. Default ``""``.
     """
     marker_start_time = timestamp2long(marker_start_time)
     marker_end_time = timestamp2long(marker_end_time)
-    # .NET objects, so pylint: disable=invalid-name
-    newRangeMarker = Marker(
-        int(marker_start_time), int(marker_end_time), marker_label, "MARKER", ""
+    newRangeMarker = Marker(  # .NET objects, so pylint: disable=invalid-name
+        int(marker_start_time),
+        int(marker_end_time),
+        marker_label,
+        marker_group,
+        marker_description,
     )
-    # .NET objects, so pylint: disable=invalid-name
-    newMarkers = Array[Marker]([newRangeMarker])
+    newMarkers = Array[Marker](  # .NET objects, so pylint: disable=invalid-name
+        [newRangeMarker]
+    )
     session.Markers.Add(newMarkers)
+    logger.info(
+        'Range marker "%s" added (%s → %s).',
+        marker_label,
+        marker_start_time,
+        marker_end_time,
+    )
+
+
+def add_markers_batch(
+    session: Session,
+    markers: list[dict],
+) -> None:
+    """Add multiple markers to the session in a single call.
+
+    Each marker is a dict with the following keys:
+
+    Point marker::
+
+        {"time": pd.Timestamp, "label": str}
+
+    Range marker::
+
+        {"start_time": pd.Timestamp, "end_time": pd.Timestamp,
+         "label": str, "group": str (optional), "description": str (optional)}
+
+    Args:
+        session: MESL.SqlRace.Domain.Session to add markers to.
+        markers: List of marker dicts.
+    """
+    net_markers = []
+    for m in markers:
+        if "start_time" in m:
+            start = int(timestamp2long(m["start_time"]))
+            end = int(timestamp2long(m["end_time"]))
+            net_markers.append(
+                Marker(
+                    start,
+                    end,
+                    m["label"],
+                    m.get("group", "MARKER"),
+                    m.get("description", ""),
+                )
+            )
+        else:
+            t = int(timestamp2long(m["time"]))
+            net_markers.append(Marker(t, m["label"]))
+
+    session.Markers.Add(Array[Marker](net_markers))
+    logger.info("%d markers added in batch.", len(net_markers))
+
+
+def set_session_details(
+    session: Session,
+    details: dict[str, str],
+) -> None:
+    """Set session-level metadata (e.g. Driver, Circuit, Vehicle).
+
+    Each key-value pair is written via
+    ``session.UpdateUnformattedSessionDetail(key, value)``.  Common keys
+    recognised by ATLAS include ``Driver``, ``Circuit``, ``Vehicle``,
+    ``Event``, ``Session``, ``Comment``, etc.
+
+    Args:
+        session: MESL.SqlRace.Domain.Session to update.
+        details: Mapping of detail name → value.
+
+    Example::
+
+        set_session_details(session, {
+            "Driver": "Max Verstappen",
+            "Circuit": "Silverstone",
+            "Vehicle": "MCL60",
+            "Event": "British GP 2026",
+        })
+    """
+    for key, value in details.items():
+        session.UpdateUnformattedSessionDetail(str(key), str(value))
+        logger.info('Session detail "%s" = "%s"', key, value)
+
+
+# ---------------------------------------------------------------------------
+# Synchro (variable-rate) data
+# ---------------------------------------------------------------------------
+
+def compute_delta_scale(intervals_ns: np.ndarray) -> int:
+    """Compute the GCD of all sample intervals in a packet.
+
+    Args:
+        intervals_ns: 1-D int64 array of inter-sample intervals in nanoseconds.
+
+    Returns:
+        The greatest common divisor of all intervals (nanoseconds).
+    """
+    if len(intervals_ns) == 0:
+        return 1
+    return int(functools.reduce(math.gcd, intervals_ns.astype(np.int64)))
+
+
+def pack_synchro_packet(
+    samples: np.ndarray,
+    intervals_ns: np.ndarray,
+    delta_scale: int,
+) -> bytes:
+    """Pack samples and intervals into the interleaved synchro byte format.
+
+    Format per pair: ``[sample (float64 LE, 8 B)] [scaled_interval (uint16 LE, 2 B)]``
+    The last sample has no trailing interval.
+
+    Uses a NumPy structured array for zero-copy vectorised packing instead of a
+    Python-level ``struct.pack`` loop.
+
+    Args:
+        samples: 1-D float64 array of sample values (length N).
+        intervals_ns: 1-D int64 array of inter-sample intervals (length N-1).
+        delta_scale: The GCD used to scale intervals into uint16.
+
+    Returns:
+        Packed byte buffer.
+
+    Raises:
+        OverflowError: If any scaled interval exceeds uint16 range (65 535).
+    """
+    scaled = intervals_ns // delta_scale
+    if len(scaled) > 0 and scaled.max() > 65535:
+        raise OverflowError(
+            f"Scaled interval {scaled.max()} exceeds uint16 range (65535). "
+            f"Reduce packet_size or check interval data."
+        )
+
+    paired_dtype = np.dtype([("sample", "<f8"), ("interval", "<u2")])
+    paired = np.empty(len(intervals_ns), dtype=paired_dtype)
+    paired["sample"] = samples[:-1].astype(np.float64)
+    paired["interval"] = scaled.astype(np.uint16)
+
+    return paired.tobytes() + samples[-1:].astype(np.float64).tobytes()
+
+
+def _packet_fits_uint16(intervals_ns: np.ndarray) -> bool:
+    """Check whether a set of intervals can be GCD-scaled into uint16."""
+    if len(intervals_ns) == 0:
+        return True
+    gcd = int(functools.reduce(math.gcd, intervals_ns.astype(np.int64)))
+    if gcd == 0:
+        gcd = 1
+    return int(intervals_ns.max()) // gcd <= 65535
+
+
+def split_into_packets(
+    samples: np.ndarray,
+    timestamps_ns: np.ndarray,
+    packet_size: int = 8000,
+) -> list[dict]:
+    """Split synchro data into sized packets that satisfy the uint16 constraint.
+
+    After the initial size-based split, any packet whose intervals would
+    overflow ``uint16`` after GCD scaling is recursively halved until every
+    packet is valid.
+
+    Args:
+        samples: 1-D float64 sample array (length N).
+        timestamps_ns: 1-D int64 timestamp array (length N).
+        packet_size: Maximum number of samples per packet.
+
+    Returns:
+        List of dicts, each with ``samples``, ``intervals_ns``, ``timestamp``.
+    """
+    intervals_ns = np.diff(timestamps_ns)
+    packets: list[dict] = []
+    n = len(samples)
+
+    raw_chunks: list[tuple[int, int]] = []
+    for start in range(0, n, packet_size):
+        raw_chunks.append((start, min(start + packet_size, n)))
+
+    stack = list(reversed(raw_chunks))
+    while stack:
+        start, end = stack.pop()
+        if end - start < 2:
+            packets.append(
+                {
+                    "samples": samples[start:end],
+                    "intervals_ns": np.array([], dtype=np.int64),
+                    "timestamp": int(timestamps_ns[start]),
+                }
+            )
+            continue
+
+        pkt_intervals = intervals_ns[start : end - 1]
+        if _packet_fits_uint16(pkt_intervals):
+            packets.append(
+                {
+                    "samples": samples[start:end],
+                    "intervals_ns": pkt_intervals,
+                    "timestamp": int(timestamps_ns[start]),
+                }
+            )
+        else:
+            mid = (start + end) // 2
+            stack.append((mid, end))
+            stack.append((start, mid))
+
+    return packets
+
+
+def _create_synchro_config(
+    session: Session,
+    parameter_name: str,
+    app_group: str,
+    param_group: str,
+    unit: str,
+    description: str,
+    display_format: str,
+    display_limits: tuple | None,
+    warning_limits: tuple | None,
+    samples: np.ndarray,
+) -> int:
+    """Create a synchro channel and parameter in the session config.
+
+    Returns:
+        The channel ID assigned to this parameter.
+    """
+    config_id = f"{random.randint(0, 999999):05x}"
+    config_mgr = ConfigurationSetManager.CreateConfigurationSetManager()
+    config = config_mgr.Create(
+        session.ConnectionString, config_id, "Pandlas synchro config"
+    )
+
+    group = ParameterGroup(param_group, param_group)
+    config.AddParameterGroup(group)
+
+    group_ids = NETList[String]()
+    group_ids.Add(group.Identifier)
+    app = ApplicationGroup(app_group, app_group, None, group_ids)
+    app.SupportsRda = False
+    config.AddGroup(app)
+
+    conv_name = f"CONV_{parameter_name}:{app_group}"
+    config.AddConversion(
+        RationalConversion.CreateSimple1To1Conversion(conv_name, unit, display_format)
+    )
+
+    channel_id = session.ReserveNextAvailableRowChannelId() % 2147483647
+    channel = Channel(
+        channel_id,
+        f"{parameter_name}_SynchroChannel",
+        0,
+        DataType.Double64Bit,
+        ChannelDataSourceType.Synchro,
+    )
+    config.AddChannel(channel)
+
+    param_id = f"{parameter_name}:{app_group}"
+    group_idents = NETList[String]()
+    group_idents.Add(param_group)
+
+    channel_ids = NETList[UInt32]()
+    channel_ids.Add(channel_id)
+
+    disp_min = float(samples.min()) if display_limits is None else display_limits[0]
+    disp_max = float(samples.max()) if display_limits is None else display_limits[1]
+    warn_min = disp_min if warning_limits is None else warning_limits[0]
+    warn_max = disp_max if warning_limits is None else warning_limits[1]
+
+    param = Parameter(
+        param_id,
+        parameter_name,
+        description or f"{parameter_name} description",
+        float(disp_max),
+        float(disp_min),
+        float(warn_max),
+        float(warn_min),
+        0.0,
+        0xFFFF,
+        0,
+        conv_name,
+        group_idents,
+        channel_ids,
+        app_group,
+        display_format,
+        unit,
+    )
+    config.AddParameter(param)
+
+    try:
+        config.Commit()
+    except ConfigurationSetAlreadyExistsException:
+        logger.warning("Config %s already exists.", config_id)
+
+    session.UseLoggingConfigurationSet(config.Identifier)
+    logger.info("Synchro config created for %s.", param_id)
+
+    return channel_id
+
+
+def add_synchro_data(
+    session: Session,
+    samples: np.ndarray,
+    timestamps: Union[np.ndarray, pd.DatetimeIndex],
+    parameter_name: str,
+    app_group: str = "SynchroApp",
+    param_group: str = "SynchroGroup",
+    unit: str = "",
+    description: str = "",
+    display_format: str = "%5.2f",
+    display_limits: tuple[float, float] | None = None,
+    warning_limits: tuple[float, float] | None = None,
+    packet_size: int = 8000,
+    show_progress_bar: bool = True,
+) -> None:
+    """Write variable-rate (synchro) data to an ATLAS session.
+
+    Creates the synchro channel configuration if the parameter doesn't already
+    exist, then writes the data in sized packets via
+    ``session.AddSynchroChannelData()``.
+
+    Args:
+        session: MESL.SqlRace.Domain.Session to write to.
+        samples: 1-D float64 array of sample values.
+        timestamps: Timestamps for each sample.  Accepts ``pd.DatetimeIndex``
+            (converted via ``timestamp2long``) or a raw ``int64`` numpy array
+            (nanoseconds in session time-base).
+        parameter_name: Name of the synchro parameter.
+        app_group: Application group name.
+        param_group: Parameter group name.
+        unit: Engineering unit string.
+        description: Parameter description.
+        display_format: Printf-style display format.
+        display_limits: ``(min, max)`` display range override.
+        warning_limits: ``(min, max)`` warning range override.
+        packet_size: Maximum samples per packet (default 8 000).
+        show_progress_bar: Show a tqdm progress bar.
+    """
+    samples = np.asarray(samples, dtype=np.float64)
+
+    if isinstance(timestamps, pd.DatetimeIndex):
+        timestamps_ns = timestamp2long(timestamps).astype(np.int64)
+    else:
+        timestamps_ns = np.asarray(timestamps, dtype=np.int64)
+
+    if len(samples) != len(timestamps_ns):
+        raise ValueError(
+            f"samples ({len(samples)}) and timestamps ({len(timestamps_ns)}) "
+            f"must have the same length."
+        )
+
+    param_id = f"{parameter_name}:{app_group}"
+    if session.ContainsParameter(param_id):
+        parameter = session.GetParameter(param_id)
+        channel_id = parameter.Channels[0].Id
+        logger.debug("Synchro parameter %s already exists.", param_id)
+    else:
+        channel_id = _create_synchro_config(
+            session,
+            parameter_name,
+            app_group,
+            param_group,
+            unit,
+            description,
+            display_format,
+            display_limits,
+            warning_limits,
+            samples,
+        )
+
+    packets = split_into_packets(samples, timestamps_ns, packet_size)
+    seq = 0
+
+    for pkt in tqdm(packets, desc="Synchro packets", disable=not show_progress_bar):
+        pkt_samples = pkt["samples"]
+        pkt_intervals = pkt["intervals_ns"]
+
+        if len(pkt_samples) < 2:
+            continue
+
+        delta_scale = compute_delta_scale(pkt_intervals)
+        if delta_scale == 0:
+            delta_scale = 1
+
+        data_bytes = pack_synchro_packet(pkt_samples, pkt_intervals, delta_scale)
+
+        session.AddSynchroChannelData(
+            int(pkt["timestamp"]),
+            int(channel_id),
+            Byte(seq % 256),
+            int(delta_scale),
+            bytes(data_bytes),
+        )
+        seq += 1
+
+    logger.info(
+        "Wrote %d synchro packets (%d samples) for %s.",
+        len(packets),
+        len(samples),
+        param_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Text (enumerated) channels
+# ---------------------------------------------------------------------------
+
+def _create_text_config(
+    session: Session,
+    parameter_name: str,
+    app_group: str,
+    param_group: str,
+    description: str,
+    unique_labels: list[str],
+    default_label: str,
+) -> int:
+    """Create a text channel config with TextConversion lookup.
+
+    Uses ``DataType.Signed16Bit`` with ``ChannelDataSourceType.RowData``
+    and a ``TextConversion`` that maps integer indices to string labels.
+    The format string ``%s`` tells ATLAS to display the converted text.
+
+    Returns:
+        The channel ID assigned to this parameter.
+    """
+    config_id = f"{random.randint(0, 999999):05x}"
+    config_mgr = ConfigurationSetManager.CreateConfigurationSetManager()
+    config = config_mgr.Create(
+        session.ConnectionString, config_id, "Pandlas text channel config"
+    )
+
+    group = ParameterGroup(param_group, param_group)
+    config.AddParameterGroup(group)
+
+    group_ids = NETList[String]()
+    group_ids.Add(group.Identifier)
+    app = ApplicationGroup(app_group, app_group, None, group_ids)
+    app.SupportsRda = False
+    config.AddGroup(app)
+
+    # TextConversion: maps integer indices to string labels
+    conv_name = f"TEXT_{parameter_name}:{app_group}"
+    numeric_values = Array[Double](
+        [float(i) for i in range(len(unique_labels))]
+    )
+    string_values = Array[String](unique_labels)
+    text_conv = TextConversion.Create(
+        conv_name,           # name
+        "",                  # units
+        "%s",                # format string — tells ATLAS to display text
+        numeric_values,      # double[] values
+        string_values,       # string[] stringValues
+        default_label,       # default value
+    )
+    config.AddConversion(text_conv)
+
+    # Channel — Signed16Bit to match the integer index encoding
+    channel_id = session.ReserveNextAvailableRowChannelId() % 2147483647
+    channel = Channel(
+        channel_id,
+        f"{parameter_name}_TextChannel",
+        0,
+        DataType.Signed16Bit,
+        ChannelDataSourceType.RowData,
+    )
+    config.AddChannel(channel)
+
+    param_id = f"{parameter_name}:{app_group}"
+    group_idents = NETList[String]()
+    group_idents.Add(param_group)
+
+    channel_ids = NETList[UInt32]()
+    channel_ids.Add(channel_id)
+
+    n_labels = len(unique_labels)
+    param = Parameter(
+        param_id,
+        parameter_name,
+        description or f"{parameter_name} text channel",
+        float(n_labels - 1),
+        0.0,
+        float(n_labels - 1),
+        0.0,
+        0.0,
+        0xFFFF,
+        0,
+        conv_name,
+        group_idents,
+        channel_ids,
+        app_group,
+        "%s",
+        "",
+    )
+    config.AddParameter(param)
+
+    try:
+        config.Commit()
+    except ConfigurationSetAlreadyExistsException:
+        logger.warning("Config %s already exists.", config_id)
+
+    session.UseLoggingConfigurationSet(config.Identifier)
+    logger.info("Text config created for %s (%d labels).", param_id, n_labels)
+
+    return channel_id
+
+
+def add_text_channel(
+    session: Session,
+    parameter_name: str,
+    values: Union[list, np.ndarray, pd.Series, pd.Categorical],
+    timestamps: Union[pd.DatetimeIndex, np.ndarray],
+    application_group: str = "TextApp",
+    param_group: str = "TextGroup",
+    description: str = "",
+    default_label: str = "Unknown",
+) -> None:
+    """Write an enumerated text channel to an ATLAS session.
+
+    Builds a ``TextConversion`` lookup table from the unique string values,
+    encodes each value as a ``Signed16Bit`` integer index, and writes the data
+    as a normal row-data channel.  ATLAS displays the string labels via the
+    ``TextConversion``.
+
+    Args:
+        session: MESL.SqlRace.Domain.Session to write to.
+        parameter_name: Name of the text parameter.
+        values: Sequence of string values (one per timestamp).
+        timestamps: ``pd.DatetimeIndex`` or int64 nanosecond array.
+        application_group: Application group name.
+        param_group: Parameter group name.
+        description: Parameter description.
+        default_label: Default label for values not in the lookup table.
+    """
+    # Convert values to list of strings
+    if isinstance(values, pd.Series):
+        str_values = values.astype(str).tolist()
+    elif isinstance(values, np.ndarray):
+        str_values = [str(v) for v in values]
+    else:
+        str_values = [str(v) for v in values]
+
+    # Convert timestamps
+    if isinstance(timestamps, pd.DatetimeIndex):
+        timestamps_ns = timestamp2long(timestamps).astype(np.int64)
+    else:
+        timestamps_ns = np.asarray(timestamps, dtype=np.int64)
+
+    if len(str_values) != len(timestamps_ns):
+        raise ValueError(
+            f"values ({len(str_values)}) and timestamps ({len(timestamps_ns)}) "
+            f"must have the same length."
+        )
+
+    # Build lookup table: unique string → integer index
+    unique_labels = list(dict.fromkeys(str_values))
+    label_to_idx = {label: i for i, label in enumerate(unique_labels)}
+
+    # Encode as int16 (matches Signed16Bit channel)
+    encoded = np.array(
+        [label_to_idx[v] for v in str_values], dtype=np.int16
+    )
+
+    # Create config if parameter doesn't exist
+    param_id = f"{parameter_name}:{application_group}"
+    if not session.ContainsParameter(param_id):
+        _create_text_config(
+            session,
+            parameter_name,
+            application_group,
+            param_group,
+            description,
+            unique_labels,
+            default_label,
+        )
+
+    # Get channel ID
+    parameter = session.GetParameter(param_id)
+    channel_id = parameter.Channels[0].Id
+
+    # Write data — 2 bytes per int16 sample
+    ts_array = Array[Int64](timestamps_ns.tolist())
+    data_bytes = bytes(encoded.tobytes())
+    session.AddRowData(int(channel_id), ts_array, data_bytes, 2, False)
+
+    logger.info(
+        "Wrote %d text samples for %s (%d unique labels).",
+        len(str_values),
+        param_id,
+        len(unique_labels),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+_PRIORITY_MAP = {
+    "low": EventPriorityType.Low,
+    "medium": EventPriorityType.Medium,
+    "high": EventPriorityType.High,
+}
+
+
+def add_events(
+    session: Session,
+    df: pd.DataFrame,
+    timestamp_column: str = "timestamp",
+    status_column: str = None,
+    application_group: str = "Events",
+    description: str = "Events",
+    priority: str = "medium",
+    conversion_format: str = "%5.2f",
+    event_definition_id: int = None,
+) -> int:
+    """Write a DataFrame of events to an ATLAS session.
+
+    Each row in *df* becomes one event. Every numeric column (excluding
+    *timestamp_column* and *status_column*) is attached as an event data value.
+
+    Args:
+        session: An open ATLAS session in write mode.
+        df: DataFrame where each row is an event. Must contain a
+            *timestamp_column* of ``pd.Timestamp`` (or int64 nanoseconds)
+            and one or more numeric value columns.
+        timestamp_column: Name of the column holding event times.
+        status_column: Optional column with a string label per event
+            (e.g. ``"LOCKUP-001"``). Shown in the ATLAS **Status** column.
+            When *None*, an auto-incrementing label like
+            ``"BrakeApp_001"`` is generated.
+        application_group: ATLAS application group name.
+        description: Human-readable description shown in ATLAS.
+        priority: ``"low"``, ``"medium"`` (default), or ``"high"``.
+        conversion_format: C-style format string for numeric display.
+        event_definition_id: Optional fixed ID (0–0xFFFF). Auto-generated
+            if *None*.
+
+    Returns:
+        Number of events written.
+
+    Example::
+
+        import pandas as pd
+        from pandlas import SQLRaceDBConnection, add_events
+
+        events = pd.DataFrame({
+            "timestamp": pd.date_range("2026-04-01 14:00", periods=5, freq="30s"),
+            "Status":         ["LK-001", "LK-002", "LK-003", "LK-004", "LK-005"],
+            "LockupPressure": [32.1, 28.5, 35.0, 30.2, 29.8],
+            "WheelSlip":      [0.12, 0.08, 0.15, 0.10, 0.09],
+        })
+
+        with SQLRaceDBConnection(..., mode="w") as session:
+            # ... write row data first ...
+            add_events(session, events, status_column="Status",
+                       description="Lockup Events",
+                       priority="high", application_group="BrakeApp")
+    """
+    if timestamp_column not in df.columns:
+        raise ValueError(f"Column '{timestamp_column}' not found in DataFrame.")
+
+    # Resolve priority
+    net_priority = _PRIORITY_MAP.get(priority.lower())
+    if net_priority is None:
+        raise ValueError(
+            f"Invalid priority '{priority}'. Use 'low', 'medium', or 'high'."
+        )
+
+    # Columns excluded from numeric data
+    exclude = {timestamp_column}
+    if status_column is not None:
+        if status_column not in df.columns:
+            raise ValueError(f"Column '{status_column}' not found in DataFrame.")
+        exclude.add(status_column)
+
+    # Separate timestamps from value columns
+    value_cols = [c for c in df.columns if c not in exclude]
+    if not value_cols:
+        raise ValueError(
+            "DataFrame must have at least one numeric column besides the "
+            "timestamp and status columns."
+        )
+
+    # Convert timestamps to nanosecond int64
+    ts_series = df[timestamp_column]
+    if pd.api.types.is_datetime64_any_dtype(ts_series):
+        timestamps_ns = timestamp2long(pd.DatetimeIndex(ts_series)).astype(np.int64)
+    else:
+        timestamps_ns = np.asarray(ts_series, dtype=np.int64)
+
+    # Auto-generate event definition ID
+    if event_definition_id is None:
+        event_definition_id = random.randint(0x0001, 0xFFFE)
+
+    # Create event configuration
+    conn_str = session.ConnectionString
+    config_name = f"EventCfg_{application_group}_{event_definition_id}"
+    config = ConfigurationSetManager.CreateConfigurationSetManager() \
+        .Create(conn_str, config_name, f"{description} config")
+
+    # One rational conversion per value column
+    conv_names = []
+    for col in value_cols:
+        conv_name = f"conv_{col}_{event_definition_id}"
+        config.AddConversion(
+            RationalConversion.CreateSimple1To1Conversion(
+                conv_name, "", conversion_format,
+            )
+        )
+        conv_names.append(conv_name)
+
+    # Create event definition
+    conv_array = Array[String](conv_names)
+    event_def = EventDefinition(
+        event_definition_id,
+        description,
+        net_priority,
+        conv_array,
+        application_group,
+    )
+    config.AddEventDefinition(event_def)
+
+    try:
+        config.Commit()
+    except ConfigurationSetAlreadyExistsException:
+        logger.debug("Event config %s already exists, reusing.", config_name)
+
+    session.UseLoggingConfigurationSet(config.Identifier, UInt32(100))
+
+    # Write each row as an event
+    n_written = 0
+    for i in range(len(df)):
+        ts = int(timestamps_ns[i])
+        raw_values = [float(df[col].iloc[i]) for col in value_cols]
+        raw_array = Array[Double](raw_values)
+
+        if status_column is not None:
+            status_text = str(df[status_column].iloc[i])
+        else:
+            status_text = f"{application_group}_{i + 1:03d}"
+
+        session.Events.AddEventData(
+            event_definition_id, application_group, ts, raw_array,
+            False, status_text,
+        )
+        n_written += 1
+
+    logger.info(
+        "Wrote %d events (%s) with %d value(s) each to '%s'.",
+        n_written,
+        description,
+        len(value_cols),
+        application_group,
+    )
+    return n_written
+

--- a/pandlas/__init__.py
+++ b/pandlas/__init__.py
@@ -9,4 +9,18 @@ from importlib.metadata import version
 __version__ = version(__package__)
 
 from pandlas.session_frame import SessionFrame
-from pandlas.SqlRace import SQLiteConnection, Ssn2Session, SQLRaceDBConnection
+from pandlas.SqlRace import (
+    SQLiteConnection,
+    Ssn2Session,
+    SQLRaceDBConnection,
+    get_samples,
+    add_lap,
+    update_lap,
+    add_point_marker,
+    add_range_marker,
+    add_markers_batch,
+    set_session_details,
+    add_synchro_data,
+    add_text_channel,
+    add_events,
+)

--- a/pandlas/session_frame.py
+++ b/pandlas/session_frame.py
@@ -18,7 +18,6 @@ See Also:
 import os
 import random
 import warnings
-import struct
 from typing import Union
 import logging
 import numpy.typing as npt
@@ -109,11 +108,31 @@ class SessionFrame:
             "MyApp"
         )
         self.paramchannelID = {}  # .NET objects, so pylint: disable=invalid-name
-        self.units = {}  # TODO: move to setter method and check for datatype
-        self.descriptions = {}  # TODO: move to setter method and check for datatype
-        self.display_format = (
-            {}
-        )  # TODO: move to setter method and check for datatype and format
+        self.units = {}
+        self.descriptions = {}
+        self.display_format = {}
+        self.display_limits = {}
+        self.warning_limits = {}
+        self.parameter_group_separator = None  # e.g. "/" to split "Chassis/DamperFL"
+
+    def _resolve_param_group(self, column_name: str) -> tuple[str, str]:
+        """Resolve the parameter group and clean parameter name for a column.
+
+        When ``parameter_group_separator`` is set, the column name is split on
+        the separator.  The first part becomes the parameter group identifier
+        and the second part becomes the parameter name.
+
+        When the separator is ``None`` (default), the column name is used as-is
+        and the default ``ParameterGroupIdentifier`` is returned.
+
+        Returns:
+            ``(parameter_group, parameter_name)``
+        """
+        sep = self.parameter_group_separator
+        if sep and sep in column_name:
+            parts = column_name.split(sep, 1)
+            return parts[0], parts[1]
+        return self.ParameterGroupIdentifier, column_name
 
     def to_atlas_session(self, session: Session, show_progress_bar: bool = True):
         """Add the contents of the DataFrame to the ATLAS session.
@@ -126,25 +145,19 @@ class SessionFrame:
         If there is a parameter with the same name and app group present in the session,
         it will just add to that existing channel.
 
-        When creating new parameters in the config, Pandlas will utilise df.atlas.unit
-        attribute to set the parameter unit. This should be provided in the form of a
-        dictionary, where the keys are the parameter identifiers and the values are the
-        units, both in string.
-        If none have been provided, a default value of no unit "" will be set.
+        Parameter metadata can be customised via the following attributes, all provided
+        as dictionaries keyed by parameter identifier
+        (``"{column_name}:{ApplicationGroupName}"``):
 
-        When creating new parameters in the config, Pandlas will utilise
-        df.atlas.description attribute to set the parameter description. This should be
-        provided in the form of a dictionary, where the keys are the parameter
-        identifiers and the values are the units, both in string.
-        If none have been provided, a default value of f"{parameter_name} description"
-        will be set.
-
-        When creating new parameters in the config, Pandlas will utilise
-        df.atlas.display_format attribute to set the parameter format override. This
-        should be provided in the form of a dictionary, where the keys are the parameter
-        identifiers and the values are the units, both in string. The format override
-        must be in a valid form.
-        If none have been provided, a default value of "%5.2f" will be set.
+        - ``df.atlas.units``: Unit string for each parameter (default ``""``).
+        - ``df.atlas.descriptions``: Description string (default
+          ``"{parameter_name} description"``).
+        - ``df.atlas.display_format``: Printf-style format override (default
+          ``"%5.2f"``).
+        - ``df.atlas.display_limits``: ``(min, max)`` tuple overriding the display
+          range. When not set, the actual data min/max is used.
+        - ``df.atlas.warning_limits``: ``(min, max)`` tuple overriding the warning
+          range. When not set, the display limits are used.
 
         Args:
             session: MESL.SqlRace.Domain.Session to the data to.
@@ -188,8 +201,15 @@ class SessionFrame:
 
         # check if there is config for it already
         need_new_config = False
-        for param_name in self._obj.columns:
-            param_identifier = f"{param_name}:{self.ApplicationGroupName}"
+        # Build resolved mapping: column_name -> (group, clean_param_name)
+        col_group_map = {}
+        for col in self._obj.columns:
+            grp, clean = self._resolve_param_group(col)
+            col_group_map[col] = (grp, clean)
+
+        for col in self._obj.columns:
+            _, clean = col_group_map[col]
+            param_identifier = f"{clean}:{self.ApplicationGroupName}"
             if not session.ContainsParameter(param_identifier):
                 need_new_config = True
 
@@ -204,37 +224,25 @@ class SessionFrame:
                 session.ConnectionString, config_identifier, config_decription
             )
 
-            # Add param group
-            parameterGroupIdentifier = (  # .NET objects, so pylint: disable=invalid-name
-                self.ParameterGroupIdentifier
-            )
-            group1 = ParameterGroup(parameterGroupIdentifier, parameterGroupIdentifier)
-            config.AddParameterGroup(group1)
+            # Discover unique parameter groups from columns
+            unique_groups = list(dict.fromkeys(
+                grp for grp, _ in col_group_map.values()
+            ))
 
-            # Add app group
-            applicationGroupName = (  # .NET objects, so pylint: disable=invalid-name
-                self.ApplicationGroupName
-            )
-            parameterGroupIds = NETList[  # .NET objects, so pylint: disable=invalid-name
-                String
-            ]()
-            parameterGroupIds.Add(  # .NET objects, so pylint: disable=invalid-name
-                group1.Identifier
-            )
-            applicationGroup = (  # .NET objects, so pylint: disable=invalid-name
-                ApplicationGroup(
-                    applicationGroupName, applicationGroupName, None, parameterGroupIds
-                )
+            # Add all parameter groups
+            parameterGroupIds = NETList[String]()
+            for grp_name in unique_groups:
+                pg = ParameterGroup(grp_name, grp_name)
+                config.AddParameterGroup(pg)
+                parameterGroupIds.Add(pg.Identifier)
+
+            # Add app group with all parameter groups
+            applicationGroupName = self.ApplicationGroupName
+            applicationGroup = ApplicationGroup(
+                applicationGroupName, applicationGroupName, None, parameterGroupIds
             )
             applicationGroup.SupportsRda = False
             config.AddGroup(applicationGroup)
-
-            parameterGroupIdentifier = (  # .NET objects, so pylint: disable=invalid-name
-                self.ParameterGroupIdentifier
-            )
-            applicationGroupName = (  # .NET objects, so pylint: disable=invalid-name
-                self.ApplicationGroupName
-            )
 
             # Create channel conversion function
             conversion_function_name = "Simple1To1"
@@ -245,12 +253,13 @@ class SessionFrame:
             )
 
             # obtain the data
-            for param_name in tqdm(
+            for col in tqdm(
                 self._obj.columns,
                 desc="Creating channels",
                 disable=not show_progress_bar,
             ):
-                param_identifier = f"{param_name}:{self.ApplicationGroupName}"
+                grp, clean = col_group_map[col]
+                param_identifier = f"{clean}:{self.ApplicationGroupName}"
                 # if parameter exists already, then do not create a new parameter
                 if session.ContainsParameter(param_identifier):
                     logger.debug(
@@ -258,7 +267,7 @@ class SessionFrame:
                     )
                     continue
 
-                data = self._obj.loc[:, param_name].dropna().to_numpy()
+                data = self._obj.loc[:, col].dropna().to_numpy()
                 dispmax = data.max()
                 dispmin = data.min()
                 warnmax = dispmax
@@ -270,17 +279,17 @@ class SessionFrame:
                 )
                 # TODO: this is a stupid workaround because it takes UInt32 but it cast
                 #  it to Int32 internally...
-                self._add_channel(config, myParamChannelId, param_name)
+                self._add_channel(config, myParamChannelId, col)
 
                 #  Add param
                 self._add_param(
                     config,
                     applicationGroupName,
                     conversion_function_name,
-                    parameterGroupIdentifier,
+                    grp,
                     dispmax,
                     dispmin,
-                    param_name,
+                    col,
                     warnmax,
                     warnmin,
                 )
@@ -294,29 +303,27 @@ class SessionFrame:
             session.UseLoggingConfigurationSet(config.Identifier)
 
         # Obtain the channel Id for the existing parameters
-        for param_name in self._obj.columns:
-            param_identifier = f"{param_name}:{self.ApplicationGroupName}"
+        for col in self._obj.columns:
+            _, clean = col_group_map[col]
+            param_identifier = f"{clean}:{self.ApplicationGroupName}"
             if not session.ContainsParameter(param_identifier):
                 continue
-            param_identifier = f"{param_name}:{self.ApplicationGroupName}"
             parameter = session.GetParameter(param_identifier)
             if parameter.Channels.Count != 1:
                 logger.warning(
                     "Parameter %s contains more than 1 channel.", param_identifier
                 )
-            self.paramchannelID[param_name] = parameter.Channels[0].Id
+            self.paramchannelID[col] = parameter.Channels[0].Id
 
         # write it to the session
-        for param_name in tqdm(
+        for col in tqdm(
             self._obj.columns, desc="Adding data", disable=not show_progress_bar
         ):
-            series = self._obj.loc[:, param_name].dropna()
+            series = self._obj.loc[:, col].dropna()
             timestamps = series.index
             data = series.to_numpy()
             myParamChannelId = (    # .NET objects, so pylint: disable=invalid-name
-                self.paramchannelID[
-                    param_name
-                ]
+                self.paramchannelID[col]
             )
             self.add_data(session, myParamChannelId, data, timestamps)
 
@@ -334,7 +341,7 @@ class SessionFrame:
         ParameterGroupIdentifier: str,  # .NET objects, so pylint: disable=invalid-name
         display_max: float,
         display_min: float,
-        parameter_name: str,
+        column_name: str,
         warning_max: float,
         warning_min: float,
     ):
@@ -347,31 +354,57 @@ class SessionFrame:
             ParameterGroupIdentifier: ID of the ParameterGroup.
             display_max: Display maximum.
             display_min: Display minimum.
-            parameter_name: Parameter name.
+            column_name: Original DataFrame column name (used to look up channel ID).
             warning_max: Warning maximum.
             warning_min: Warning minimum.
 
         """
+        _, clean_name = self._resolve_param_group(column_name)
         # TODO: guard again NaNs
         myParamChannelId = NETList[  # .NET objects, so pylint: disable=invalid-name
             UInt32
         ]()
-        myParamChannelId.Add(self.paramchannelID[parameter_name])
-        parameterIdentifier = f"{parameter_name}:{ApplicationGroupName}"  # .NET objects, so pylint: disable=invalid-name
+        myParamChannelId.Add(self.paramchannelID[column_name])
+        parameterIdentifier = f"{clean_name}:{ApplicationGroupName}"  # .NET objects, so pylint: disable=invalid-name
         parameterGroupIdentifiers = NETList[  # .NET objects, so pylint: disable=invalid-name
             String
         ]()
         parameterGroupIdentifiers.Add(ParameterGroupIdentifier)
 
+        # Metadata lookup: try both clean identifier and full column-based identifier
+        full_identifier = f"{column_name}:{ApplicationGroupName}"
         param_description = self.descriptions.get(
-            parameterIdentifier, f"{parameter_name} description"
+            parameterIdentifier,
+            self.descriptions.get(
+                full_identifier, f"{clean_name} description"
+            ),
         )
-        param_format = self.display_format.get(parameterIdentifier, "%5.2f")
-        param_unit = self.units.get(parameterIdentifier, "")
+        param_format = self.display_format.get(
+            parameterIdentifier,
+            self.display_format.get(full_identifier, "%5.2f"),
+        )
+        param_unit = self.units.get(
+            parameterIdentifier,
+            self.units.get(full_identifier, ""),
+        )
+
+        param_display_limits = self.display_limits.get(
+            parameterIdentifier,
+            self.display_limits.get(full_identifier, None),
+        )
+        if param_display_limits is not None:
+            display_min, display_max = param_display_limits
+
+        param_warning_limits = self.warning_limits.get(
+            parameterIdentifier,
+            self.warning_limits.get(full_identifier, None),
+        )
+        if param_warning_limits is not None:
+            warning_min, warning_max = param_warning_limits
 
         myParameter = Parameter(  # .NET objects, so pylint: disable=invalid-name
             parameterIdentifier,
-            parameter_name,
+            clean_name,
             param_description,
             float(display_max),
             float(display_min),
@@ -412,7 +445,7 @@ class SessionFrame:
     def add_data(
         self,
         session: Session,
-        channel_id: float,
+        channel_id: int,
         data: np.ndarray,
         timestamps: Union[pd.DatetimeIndex, npt.NDArray[np.datetime64]],
     ):
@@ -435,14 +468,8 @@ class SessionFrame:
         channelIds = NETList[UInt32]()  # .NET objects, so pylint: disable=invalid-name
         channelIds.Add(channel_id)
 
-        # databytes = data.astype(np.float32).tobytes()
-        databytes = bytearray(len(data) * 4)
-        for i, value in enumerate(data):
-            new_bytes = struct.pack("f", value)
-            databytes[i * 4 : i * 4 + len(new_bytes)] = new_bytes
+        databytes = bytes(data.astype(np.float32).tobytes())
 
-        timestamps_array = Array[Int64](len(timestamps))
-        for i, timestamp in enumerate(timestamps):
-            timestamps_array[i] = Int64(int(timestamp))
+        timestamps_array = Array[Int64](timestamps.astype(np.int64).tolist())
 
         session.AddRowData(channel_id, timestamps_array, databytes, 4, False)

--- a/tests/test_intergration.py
+++ b/tests/test_intergration.py
@@ -24,8 +24,8 @@ def test_read_write_sqlite(tmp_path):
     with sr.SQLiteConnection(SQLITE_DB_DIR, session_key=key, mode='r') as session:
         assert session_identifier == session.Identifier
         samples, timstamp = sr.get_samples(session, "Param 1:MyApp")
-        np.isclose(df["Param 1"].to_numpy(),samples)
-        np.isclose(timestamp2long(df["Param 1"].index),timstamp)
+        assert np.all(np.isclose(df["Param 1"].to_numpy(), samples))
+        assert np.all(np.isclose(timestamp2long(df["Param 1"].index), timstamp))
 
 
 @pytest.mark.atlaslicensed()
@@ -46,5 +46,5 @@ def test_read_write_sqldb(tmp_path):
     with sr.SQLRaceDBConnection(data_source, database, session_key=key, mode='r') as session:
         assert session_identifier == session.Identifier
         samples, timstamp = sr.get_samples(session, "Param 1:MyApp")
-        np.isclose(df["Param 1"].to_numpy(),samples)
-        np.isclose(timestamp2long(df["Param 1"].index),timstamp)
+        assert np.all(np.isclose(df["Param 1"].to_numpy(), samples))
+        assert np.all(np.isclose(timestamp2long(df["Param 1"].index), timstamp))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ class Test_timestamp2long:
         start_date = pd.Timestamp("2021-01-01")
         long = timestamp2long(ts, start_date)
         ts2 = long2timestamp(long.to_numpy(), start_date)
-        np.equal(ts, ts2)
+        assert np.all(np.equal(ts, ts2))
 
 
 class Test_long2timestamp:
@@ -59,7 +59,7 @@ class Test_long2timestamp:
         start_date = pd.Timestamp("2021-01-01")
         ts = long2timestamp(long, start_date)
         long2 = timestamp2long(ts, start_date)
-        np.equal(long, long2)
+        assert np.all(np.equal(long, long2))
 
     @pytest.mark.parametrize(
         "epoch", [random.randint(0, 2234860605000) for _ in range(5)]


### PR DESCRIPTION
 - Implement add_events() for ATLAS event logging with status labels
 - Consolidate synchro/text modules into SqlRace.py, remove shim files
 - Fix recorder enum bug (bool → DeleteSessionOption) for pythonnet 3.0+
 - Add complete_showcase example (all 7 features in one session)
 - Add live_weather example (Open-Meteo API, 100Hz streaming)
 - Add live_crypto example (Binance 20-asset ticker, spike alerts)
 - Add event_logging example with 3 severity levels
 - Rename example files to professional naming convention
 - Fix README: correct API signatures, imports, add Events docs
 - Add units support to all live streaming examples